### PR TITLE
Auto-detect role arn prefix using metadata api

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -49,7 +49,7 @@ func main() {
 	kingpin.Flag("kubeconfig", "Path to .kube/config (or empty for in-cluster)").Default("").StringVar(&serverConfig.KubeConfig)
 	kingpin.Flag("sync", "Pod cache sync interval").Default("1m").DurationVar(&serverConfig.PodSyncInterval)
 	kingpin.Flag("role-base-arn", "Base ARN for roles. e.g. arn:aws:iam::123456789:role/").StringVar(&serverConfig.RoleBaseARN)
-	kingpin.Flag("role-base-arn-autodetect", "Use EC2 metadata service to detect ARN prefix.").BoolVar(&serverConfig.AutoDetectBaseArn)
+	kingpin.Flag("role-base-arn-autodetect", "Use EC2 metadata service to detect ARN prefix.").BoolVar(&serverConfig.AutoDetectBaseARN)
 	kingpin.Flag("session", "Session name used when creating STS Tokens.").Default("kiam").StringVar(&serverConfig.SessionName)
 
 	kingpin.Flag("cert", "Server certificate path").Required().ExistingFileVar(&serverConfig.TLS.ServerCert)
@@ -58,7 +58,7 @@ func main() {
 
 	kingpin.Parse()
 
-	if !serverConfig.AutoDetectBaseArn && serverConfig.RoleBaseARN == "" {
+	if !serverConfig.AutoDetectBaseARN && serverConfig.RoleBaseARN == "" {
 		log.Fatal("role-base-arn not specified and not auto-detected. please specify or use --role-base-arn-autodetect")
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,16 +15,17 @@ package main
 
 import (
 	"context"
-	"github.com/pubnub/go-metrics-statsd"
-	"github.com/rcrowley/go-metrics"
-	log "github.com/sirupsen/logrus"
-	serv "github.com/uswitch/kiam/pkg/server"
-	"gopkg.in/alecthomas/kingpin.v2"
 	"net"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/pubnub/go-metrics-statsd"
+	"github.com/rcrowley/go-metrics"
+	log "github.com/sirupsen/logrus"
+	serv "github.com/uswitch/kiam/pkg/server"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func main() {
@@ -47,7 +48,8 @@ func main() {
 	kingpin.Flag("bind", "gRPC bind address").Default("localhost:9610").StringVar(&serverConfig.BindAddress)
 	kingpin.Flag("kubeconfig", "Path to .kube/config (or empty for in-cluster)").Default("").StringVar(&serverConfig.KubeConfig)
 	kingpin.Flag("sync", "Pod cache sync interval").Default("1m").DurationVar(&serverConfig.PodSyncInterval)
-	kingpin.Flag("role-base-arn", "Base ARN for roles. e.g. arn:aws:iam::123456789:role/").Required().StringVar(&serverConfig.RoleBaseARN)
+	kingpin.Flag("role-base-arn", "Base ARN for roles. e.g. arn:aws:iam::123456789:role/").StringVar(&serverConfig.RoleBaseARN)
+	kingpin.Flag("role-base-arn-autodetect", "Use EC2 metadata service to detect ARN prefix.").BoolVar(&serverConfig.AutoDetectBaseArn)
 	kingpin.Flag("session", "Session name used when creating STS Tokens.").Default("kiam").StringVar(&serverConfig.SessionName)
 
 	kingpin.Flag("cert", "Server certificate path").Required().ExistingFileVar(&serverConfig.TLS.ServerCert)
@@ -55,6 +57,10 @@ func main() {
 	kingpin.Flag("ca", "CA path").Required().ExistingFileVar(&serverConfig.TLS.CA)
 
 	kingpin.Parse()
+
+	if !serverConfig.AutoDetectBaseArn && serverConfig.RoleBaseARN == "" {
+		log.Fatal("role-base-arn not specified and not auto-detected. please specify or use --role-base-arn-autodetect")
+	}
 
 	if flags.jsonLog {
 		log.SetFormatter(&log.JSONFormatter{})
@@ -89,7 +95,7 @@ func main() {
 
 	server, err := serv.NewServer(serverConfig)
 	if err != nil {
-		log.Fatal("error creating listener:", err.Error())
+		log.Fatal("error creating listener: ", err.Error())
 	}
 
 	go func() {

--- a/pkg/aws/sts/resolver_detect_arn.go
+++ b/pkg/aws/sts/resolver_detect_arn.go
@@ -1,0 +1,63 @@
+// Portions of below were based on kube2iam (https://github.com/jtblin/kube2iam). It's
+// license is copied below:
+// Copyright (c) Jerome Touffe-Blin ("Author")
+// All rights reserved.
+
+// The BSD License
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+// OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+// IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+package sts
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// DetectARNPrefix uses the EC2 metadata API to determine the
+// current prefix.
+func DetectARNPrefix() (string, error) {
+	sess := session.Must(session.NewSession())
+	svc := ec2metadata.New(sess)
+	if !svc.Available() {
+		return "", fmt.Errorf("aws metadata api not available")
+	}
+
+	info, err := svc.IAMInfo()
+	if err != nil {
+		return "", fmt.Errorf("error accessing iam info: %s", err)
+	}
+
+	// instance profile arn will be of the form:
+	// arn:aws:iam::account-id:instance-profile/role-name
+	// so we use the instance-profile prefix as the prefix for our roles
+	parts := strings.Split(strings.Replace(info.InstanceProfileArn, "instance-profile", "role", 1), "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unexpected instance arn format: %s", info.InstanceProfileArn)
+	}
+
+	return fmt.Sprintf("%s/", parts[0]), nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,7 +39,7 @@ type Config struct {
 	PodSyncInterval          time.Duration
 	SessionName              string
 	RoleBaseARN              string
-	AutoDetectBaseArn        bool
+	AutoDetectBaseARN        bool
 	TLS                      *TLSConfig
 	ParallelFetcherProcesses int
 	PrefetchBufferSize       int
@@ -121,7 +121,7 @@ func (k *KiamServer) GetRoleCredentials(ctx context.Context, req *pb.GetRoleCred
 }
 
 func newRoleARNResolver(config *Config) (sts.ARNResolver, error) {
-	if config.AutoDetectBaseArn {
+	if config.AutoDetectBaseARN {
 		log.Infof("detecting arn prefix")
 		prefix, err := sts.DetectARNPrefix()
 		if err != nil {


### PR DESCRIPTION
This implements the behaviour requested in #16 and extends the previous refactoring for an arn resolver.

Either the role arn must be specified to the server with `--role-base-arn` or, to enable the new lookup, use `--role-base-arn-autodetect`.