### PR TITLE
Add optional role for server to assume before assuming pod roles

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -54,6 +54,7 @@ func main() {
 	kingpin.Flag("role-base-arn", "Base ARN for roles. e.g. arn:aws:iam::123456789:role/").StringVar(&serverConfig.RoleBaseARN)
 	kingpin.Flag("role-base-arn-autodetect", "Use EC2 metadata service to detect ARN prefix.").BoolVar(&serverConfig.AutoDetectBaseARN)
 	kingpin.Flag("session", "Session name used when creating STS Tokens.").Default("kiam").StringVar(&serverConfig.SessionName)
+	kingpin.Flag("assume-role-arn", "IAM Role to assume before processing requests").Default("").StringVar(&serverConfig.AssumeRoleArn)
 
 	kingpin.Flag("cert", "Server certificate path").Required().ExistingFileVar(&serverConfig.TLS.ServerCert)
 	kingpin.Flag("key", "Server private key path").Required().ExistingFileVar(&serverConfig.TLS.ServerKey)

--- a/docs/IAM.md
+++ b/docs/IAM.md
@@ -53,3 +53,20 @@ in the AWS Console, and the `assume_role_policy` in Terraform.
   ]
 }
 ```
+
+## Server IAM Role
+
+A role (different from the clutser node EC2 instance role) can optionally be
+provided for the Server to assume before interacting with the STS API (via
+`--assume-role-arn`).
+
+Using a separate Server IAM role is desirable in cases where the cluster node
+instances and IAM roles are replaced frequently. The Trust Relationship requires
+a fully qualified ARN of an existing role (no wildcards can be used), so reusing
+a role separate from any one cluster allows Pods to move between clusters
+without reconfiguring their IAM roles.
+
+The cluster node EC2 instance role will need to have `sts:AssumeRole` permission
+for this role and for there to be an entry in the Server role's trust policy.
+Application roles will need to have a trust policy entry for this role, instead
+of the cluster node role as noted above.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -43,6 +43,7 @@ type Config struct {
 	TLS                      *TLSConfig
 	ParallelFetcherProcesses int
 	PrefetchBufferSize       int
+	AssumeRoleArn            string
 }
 
 type TLSConfig struct {
@@ -150,7 +151,7 @@ func NewServer(config *Config) (*KiamServer, error) {
 	server.pods = k8s.NewPodCache(k8s.KubernetesSource(client, k8s.ResourcePods), config.PodSyncInterval, config.PrefetchBufferSize)
 	server.namespaces = k8s.NewNamespaceCache(k8s.KubernetesSource(client, k8s.ResourceNamespaces), time.Minute)
 
-	stsGateway := sts.DefaultGateway()
+	stsGateway := sts.DefaultGateway(config.AssumeRoleArn)
 	arnResolver, err := newRoleARNResolver(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This allows a stable role, independant of controller instance roles, to be used
by the server when calling `sts:AssumeRole`. The `--assume-role-arn` still needs
to have a trust relationship with the instance role where the server is running.