### PR TITLE
autodetect base arn fix for paths (#32)

### DIFF
--- a/test/unit/arn_resolver_test.go
+++ b/test/unit/arn_resolver_test.go
@@ -37,3 +37,15 @@ func TestUsesAbsoluteARN(t *testing.T) {
 		t.Error("unexpected role, was:", role)
 	}
 }
+
+func TestExtractsBaseFromInstanceArn(t *testing.T) {
+	prefix, _ := sts.BaseArn("arn:aws:iam::account-id:instance-profile/instance-role-name")
+	if prefix != "arn:aws:iam::account-id:role/" {
+		t.Error("unexpected prefix, was: ", prefix)
+	}
+
+	prefix, _ = sts.BaseArn("arn:aws:iam::account-id:instance-profile/mypath/instance-role-name")
+	if prefix != "arn:aws:iam::account-id:role/" {
+		t.Error("unexpected prefix, was: ", prefix)
+	}
+}


### PR DESCRIPTION
A slight tweak to the way the ARN base prefix is calculated to work when the instance profile arn includes a path prefix.