### PR TITLE
Allow custom session lifetime

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -54,6 +54,7 @@ func main() {
 	kingpin.Flag("role-base-arn", "Base ARN for roles. e.g. arn:aws:iam::123456789:role/").StringVar(&serverConfig.RoleBaseARN)
 	kingpin.Flag("role-base-arn-autodetect", "Use EC2 metadata service to detect ARN prefix.").BoolVar(&serverConfig.AutoDetectBaseARN)
 	kingpin.Flag("session", "Session name used when creating STS Tokens.").Default("kiam").StringVar(&serverConfig.SessionName)
+	kingpin.Flag("session-duration", "Requested session duration for STS Tokens.").Default("15m").DurationVar(&serverConfig.SessionDuration)
 	kingpin.Flag("assume-role-arn", "IAM Role to assume before processing requests").Default("").StringVar(&serverConfig.AssumeRoleArn)
 
 	kingpin.Flag("cert", "Server certificate path").Required().ExistingFileVar(&serverConfig.TLS.ServerCert)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -38,6 +38,7 @@ type Config struct {
 	KubeConfig               string
 	PodSyncInterval          time.Duration
 	SessionName              string
+	SessionDuration          time.Duration
 	RoleBaseARN              string
 	AutoDetectBaseARN        bool
 	TLS                      *TLSConfig
@@ -156,7 +157,7 @@ func NewServer(config *Config) (*KiamServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	credentialsCache := sts.DefaultCache(stsGateway, config.SessionName, arnResolver)
+	credentialsCache := sts.DefaultCache(stsGateway, config.SessionName, config.SessionDuration, arnResolver)
 	server.credentialsProvider = credentialsCache
 	server.manager = prefetch.NewManager(credentialsCache, server.pods, server.pods)
 	server.assumePolicy = Policies(NewRequestingAnnotatedRolePolicy(server.pods), NewNamespacePermittedRoleNamePolicy(server.namespaces, server.pods))

--- a/test/unit/credentials_cache_test.go
+++ b/test/unit/credentials_cache_test.go
@@ -35,7 +35,7 @@ func (s *stubGateway) Issue(ctx context.Context, roleARN, sessionName string, ex
 
 func TestRequestsCredentialsFromGatewayWithEmptyCache(t *testing.T) {
 	stubGateway := &stubGateway{c: &sts.Credentials{Code: "foo"}}
-	cache := sts.DefaultCache(stubGateway, "session", sts.DefaultResolver("prefix:"))
+	cache := sts.DefaultCache(stubGateway, "session", 15*time.Minute, sts.DefaultResolver("prefix:"))
 	ctx := context.Background()
 
 	creds, _ := cache.CredentialsForRole(ctx, "role")


### PR DESCRIPTION
Previous hardcoded session lifetime of 15m caused issues with libraries
like botocore, which have a hard set limit of refreshing token a set time
before expiry. In botocore the default happens to be 15 minutes, which
means that the session token is never cached within botocore.

This causes excess load on kiam and quite often leads to missing access
keys on the service using the tokens.

This PR adds a flag to define the lifetime of the token that is
requested from AWS API.