### PR TITLE
Allow trailing / on security-credentials endpoint

### DIFF
--- a/pkg/aws/metadata/server.go
+++ b/pkg/aws/metadata/server.go
@@ -71,7 +71,10 @@ func buildHTTPServer(config *ServerConfig, finder k8s.RoleFinder, credentials st
 		roleFinder: finder,
 		clientIP:   clientIP,
 	}
-	router.Handle("/{version}/meta-data/iam/security-credentials/", adapt(withMeter("roleName", r)))
+
+	securityCredsHandler := adapt(withMeter("roleName", r))
+	router.Handle("/{version}/meta-data/iam/security-credentials", securityCredsHandler)
+	router.Handle("/{version}/meta-data/iam/security-credentials/", securityCredsHandler)
 
 	c := &credentialsHandler{
 		roleFinder:          finder,


### PR DESCRIPTION
This commit makes it possible to reach the
http://169.254.169.254/meta-data/iam/security-credentials/ without the
trailing slash.

The Golang AWS SDK doesn't seem to call the endpoint with a trailing
slash:
https://github.com/aws/aws-sdk-go/blob/b2dc98bb584e48b0f5f39c93110633173c5da43c/aws/credentials/ec2rolecreds/ec2_role_provider_test.go#L37
I guess the implementation varies accross SDKs (the Java SDK, for
instance, seems to make its call with a trailing slash).

As a consequence, Kiam doesn't swallow requests made with this SDK and
simply forwards the request to the original EC2 instance metadata
service, which returns the instance's role name instead of the one set
in the calling pod's annotation.