### PR TITLE
Supports use of ! prefix for interface name

### DIFF
--- a/cmd/agent/iptables.go
+++ b/cmd/agent/iptables.go
@@ -16,6 +16,7 @@ package main
 import (
 	"fmt"
 	"github.com/coreos/go-iptables/iptables"
+	"strings"
 )
 
 type rules struct {
@@ -42,14 +43,19 @@ func (r *rules) Add() error {
 }
 
 func (r *rules) ruleSpec() []string {
-	return []string{
+	rules := []string{
 		"-p", "tcp",
 		"-d", metadataAddress,
 		"--dport", "80",
 		"-j", "DNAT",
 		"--to-destination", r.kiamAddress(),
-		"-i", r.hostInterface,
 	}
+	if strings.HasPrefix(r.hostInterface, "!") {
+		rules = append(rules, "!")
+	}
+	rules = append(rules, "-i", strings.TrimPrefix(r.hostInterface, "!"))
+	
+	return rules
 }
 
 func (r *rules) Remove() error {


### PR DESCRIPTION
There are some CNI implementations that make use of multiple
Elastic Network Interfaces and secondary IPs to assign pods ips
directly from the VPC ranges. For example:

    https://github.com/aws/amazon-vpc-cni-k8s
    https://github.com/lyft/cni-ipvlan-vpc-k8s

For kiam to function correctly, it is necessary to have an iptables
rule that applies to all of the interfaces that pod traffic may come
from. And since these interfaces may be added and removed on demand,
it is necessary to have DNAT rules that will continue to work as
interfaces come and go.

iptables supports inverted matching for interface names which can be
useful to include all but certain interfaces in rules. For example:

    iptables --append PREROUTING --protocol tcp \
      --destination 169.254.169.254 --dport 80  \
      \! -i loopback   --jump DNAT  --table nat \
      --to-destination 10.100.100.3:8181

will apply the DNAT rule to all interfaces except the loopback.

This change puts the "!" for inverting the interface before the name
of the interface in the rules spec that inverted rules work as
intended.