### PR TITLE
adds support for default roles

### DIFF
--- a/pkg/aws/metadata/handler_role_name.go
+++ b/pkg/aws/metadata/handler_role_name.go
@@ -23,8 +23,9 @@ import (
 )
 
 type roleHandler struct {
-	roleFinder k8s.RoleFinder
-	clientIP   clientIPFunc
+	roleFinder  k8s.RoleFinder
+	clientIP    clientIPFunc
+	defaultRole string
 }
 
 func (h *roleHandler) Handle(ctx context.Context, w http.ResponseWriter, req *http.Request) (int, error) {
@@ -46,6 +47,12 @@ func (h *roleHandler) Handle(ctx context.Context, w http.ResponseWriter, req *ht
 	if err != nil {
 		metrics.GetOrRegisterMeter("roleNameHandler.findRoleError", metrics.DefaultRegistry).Mark(1)
 		return http.StatusInternalServerError, err
+	}
+
+	if role == "" && h.defaultRole != "" {
+		metrics.GetOrRegisterMeter("roleNameHandler.defaultRole", metrics.DefaultRegistry).Mark(1)
+		fmt.Fprint(w, h.defaultRole)
+		return http.StatusOK, nil
 	}
 
 	if role == "" {

--- a/pkg/aws/metadata/server.go
+++ b/pkg/aws/metadata/server.go
@@ -39,13 +39,15 @@ type ServerConfig struct {
 	ListenPort       int
 	MetadataEndpoint string
 	AllowIPQuery     bool
+	DefaultRole      string
 }
 
-func NewConfig(port int) *ServerConfig {
+func NewConfig(port int, defaultRole string) *ServerConfig {
 	return &ServerConfig{
 		MetadataEndpoint: "http://169.254.169.254",
 		ListenPort:       port,
 		AllowIPQuery:     false,
+		DefaultRole:      defaultRole,
 	}
 }
 
@@ -70,6 +72,7 @@ func buildHTTPServer(config *ServerConfig, finder k8s.RoleFinder, credentials st
 	r := &roleHandler{
 		roleFinder: finder,
 		clientIP:   clientIP,
+		defaultRole: config.DefaultRole,
 	}
 
 	securityCredsHandler := adapt(withMeter("roleName", r))
@@ -81,6 +84,7 @@ func buildHTTPServer(config *ServerConfig, finder k8s.RoleFinder, credentials st
 		credentialsProvider: credentials,
 		clientIP:            clientIP,
 		policy:              policy,
+		defaultRole:		 config.DefaultRole,
 	}
 	router.Handle("/{version}/meta-data/iam/security-credentials/{role:.*}", adapt(withMeter("credentials", c)))
 

--- a/pkg/aws/sts/resolver_detect_arn.go
+++ b/pkg/aws/sts/resolver_detect_arn.go
@@ -54,6 +54,25 @@ func InstanceProfileArn() (string, error) {
 	return info.InstanceProfileArn, nil
 }
 
+// RoleName parses out the role name from the instance profile arn
+func RoleName(instanceProfileArn string) (string, error) {
+	parts := strings.Split(instanceProfileArn, "/")
+
+	roleName := strings.Join(parts[1:], "/")
+	return roleName, nil
+}
+
+// DetectRoleName uses the EC2 metadata API to detect the name of the 
+// role from the instance profile
+func DetectRoleName() (string, error) {
+	instanceArn, err := InstanceProfileArn()
+	if err != nil {
+		return "", err
+	}
+
+	return RoleName(instanceArn)
+}
+
 // BaseArn calculates the base arn given an instance's arn
 func BaseArn(instanceProfileArn string) (string, error) {
 	// instance profile arn will be of the form:

--- a/test/unit/arn_resolver_test.go
+++ b/test/unit/arn_resolver_test.go
@@ -49,3 +49,15 @@ func TestExtractsBaseFromInstanceArn(t *testing.T) {
 		t.Error("unexpected prefix, was: ", prefix)
 	}
 }
+
+func TestExtractsRoleNameFromInstanceArn(t *testing.T) {
+	roleName, _ := sts.RoleName("arn:aws:iam::account-id:instance-profile/instance-role-name")
+	if roleName != "instance-role-name" {
+		t.Error("unexpected role name, was: ", roleName)
+	}
+
+	roleName, _ = sts.RoleName("arn:aws:iam::account-id:instance-profile/mypath/instance-role-name")
+	if roleName != "mypath/instance-role-name" {
+		t.Error("unexpected role name, was: ", roleName)
+	}
+}


### PR DESCRIPTION
Addresses #1 
If a pod doesn't have a role specified, it can be useful in some
cases to return a default role instead of empty role. This change
adds two flags to the agent:

   --default-role lets you specify the name of the role
   --default-role-autodetect if you haven't specified a default-role
       this flag will cause kiam to attempt to look up the role using
       the instance profile arn from the metadata service

For pods that get the default role, the real ec2 metadata service is
used to lookup credentials.