### PR TITLE
Add link to sample json files directory

### DIFF
--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -13,6 +13,7 @@ go get -u github.com/cloudflare/cfssl/cmd/...
 ```
 
 ## Generate certs
+Sample cert json data provided in the [docs directory.](https://github.com/uswitch/kiam/tree/master/docs)
 
 1. Create the Certificate Authority Cert and Key
 


### PR DESCRIPTION
First of all, Kiam looks great. We're running into some performance issues with kube2iam so I'm eagerly testing this in a few clusters. Great job!

I totally missed that these json files were provided, maybe it'd help others if it was mentioned in the docs? Any changes welcome!