### PR TITLE
Add reference to amazon-vpc-cni-k8s to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This is the process that would typically be deployed as a DaemonSet to ensure th
 
 | CNI | Interface | Notes |
 |-----|-----------|-------|
-| [cni-ipvlan-vpc-k8s](https://github.com/lyft/cni-ipvlan-vpc-k8s) | `!eth0` | This CNI plugin attaches multiple ENIs to the instance. Typically eth1-ethN (N depends on the instance type) are used for pods which leaves eth0 for the kubernetes control plane. The ! prefix on the interface name inverts the match so metadata service traffic from all interfaces except eth0 will be sent to the kiam agent. |
+| [amazon-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s) and [cni-ipvlan-vpc-k8s](https://github.com/lyft/cni-ipvlan-vpc-k8s) | `!eth0` | This CNI plugin attaches multiple ENIs to the instance. Typically eth1-ethN (N depends on the instance type) are used for pods which leaves eth0 for the kubernetes control plane. The ! prefix on the interface name inverts the match so metadata service traffic from all interfaces except eth0 will be sent to the kiam agent. *Requires kiam v2.7 or newer.* |
 | [weave](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/) | `weave` |   |
 | [calico/canal](https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/flannel) | `cali+` |   |
 

--- a/deploy/agent.yaml
+++ b/deploy/agent.yaml
@@ -31,7 +31,7 @@ spec:
         - name: kiam
           securityContext:
             privileged: true
-          image: quay.io/uswitch/kiam:v2.5
+          image: quay.io/uswitch/kiam:v2.7
           command:
             - /agent
           args:

--- a/deploy/server.yaml
+++ b/deploy/server.yaml
@@ -26,7 +26,7 @@ spec:
             secretName: kiam-server-tls
       containers:
         - name: kiam
-          image: quay.io/uswitch/kiam:v2.5
+          image: quay.io/uswitch/kiam:v2.7
           imagePullPolicy: Always
           command:
             - /server


### PR DESCRIPTION
Using `!eth0` as the interface *does* work with amazon-vpc-cni-k8s, but it took a bit to figure out that I needed a newer version of kiam than the k8s manifests listed under `deploy/`.

This PR:

1. Adds a reference to amazon-vpc-cni-k8s to the README.
2. Updates the version in the manifests under `deploy/` from v2.5 to v2.7, which has the `!` prefix support for `--host-interface`.