### PR TITLE
Add option to disable user-data endpoint

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -44,6 +44,7 @@ type options struct {
 	serverAddressRefresh time.Duration
 	prometheusListen     string
 	prometheusSync       time.Duration
+	disableUserData      bool
 
 	certificatePath string
 	keyPath         string
@@ -89,6 +90,8 @@ func main() {
 	kingpin.Flag("key", "Agent key path").Required().ExistingFileVar(&opts.keyPath)
 	kingpin.Flag("ca", "CA certificate path").Required().ExistingFileVar(&opts.caPath)
 
+	kingpin.Flag("disable-user-data", "Disable the user-data endpoint").Default("false").BoolVar(&opts.disableUserData)
+
 	kingpin.Flag("prometheus-listen-addr", "Prometheus HTTP listen address. e.g. localhost:9620").StringVar(&opts.prometheusListen)
 	kingpin.Flag("prometheus-sync-interval", "How frequently to update Prometheus metrics").Default("5s").DurationVar(&opts.prometheusSync)
 
@@ -128,6 +131,7 @@ func main() {
 
 	config := http.NewConfig(opts.port)
 	config.AllowIPQuery = opts.allowIPQuery
+	config.DisableUserData = opts.disableUserData
 
 	gateway, err := kiamserver.NewGateway(opts.serverAddress, opts.serverAddressRefresh, opts.caPath, opts.certificatePath, opts.keyPath)
 	if err != nil {


### PR DESCRIPTION
The AWS EC2 user data isn't _supposed_ to contain any sensitive data, though unfortunately it isn't always the case. Pre-Kubernetes, we've limited access to the metadata service using iptables on the node. I couldn't find any existing patch for it.

This PR adds a new `--disable-user-data` boolean flag to the agent:

- When unset (the default), behavior doesn't change.
- When set to `true`, it disables the `/{version}/user-data` endpoint on the agent by returning requests to it with a HTTP 404. The [metadata doc](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) mentions that an endpoint should either return the value, or a 404.

Not sure if there are any other endpoints that other cluster operators may want to disable, but this was the obvious one for us.