### PR TITLE
wait for balancer to have some address available on gateway

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -42,6 +42,7 @@ type options struct {
 	hostInterface        string
 	serverAddress        string
 	serverAddressRefresh time.Duration
+	timeoutKiamGateway   time.Duration
 	prometheusListen     string
 	prometheusSync       time.Duration
 
@@ -85,6 +86,7 @@ func main() {
 
 	kingpin.Flag("server-address", "gRPC address to Kiam server service").Default("localhost:9610").StringVar(&opts.serverAddress)
 	kingpin.Flag("server-address-refresh", "Interval to refresh server service endpoints").Default("10s").DurationVar(&opts.serverAddressRefresh)
+	kingpin.Flag("gateway-timeout-creation", "Timeout to create the kiam gateway ").Default("50ms").DurationVar(&opts.timeoutKiamGateway)
 	kingpin.Flag("cert", "Agent certificate path").Required().ExistingFileVar(&opts.certificatePath)
 	kingpin.Flag("key", "Agent key path").Required().ExistingFileVar(&opts.keyPath)
 	kingpin.Flag("ca", "CA certificate path").Required().ExistingFileVar(&opts.caPath)
@@ -129,7 +131,10 @@ func main() {
 	config := http.NewConfig(opts.port)
 	config.AllowIPQuery = opts.allowIPQuery
 
-	gateway, err := kiamserver.NewGateway(opts.serverAddress, opts.serverAddressRefresh, opts.caPath, opts.certificatePath, opts.keyPath)
+	ctxGateway, cancelCtxGateway := context.WithTimeout(context.Background(), opts.timeoutKiamGateway)
+	defer cancelCtxGateway()
+
+	gateway, err := kiamserver.NewGateway(ctxGateway, opts.serverAddress, opts.serverAddressRefresh, opts.caPath, opts.certificatePath, opts.keyPath)
 	if err != nil {
 		log.Fatalf("error creating server gateway: %s", err.Error())
 	}


### PR DESCRIPTION
When running the health command, more often than not, the output is:
```
WARN[0000] error checking health: rpc error: code = Unavailable desc = there is no address available 
INFO[0000] healthy: ok
```
running with GRPC_GO_LOG_SEVERITY_LEVEL=info GRPC_GO_LOG_VERBOSITY_LEVEL=8 the problem is that the balancer has not been notifiied of the address before it tries to connect:
``` 
INFO: 2018/06/01 06:55:06 ccBalancerWrapper: updating state and picker called by balancer: IDLE, 0xc420205320
INFO: 2018/06/01 06:55:06 dialing to target with scheme: ""
INFO: 2018/06/01 06:55:06 could not get resolver for scheme: ""
WARN[0000] error checking health: rpc error: code = Unavailable desc = there is no address available 
INFO: 2018/06/01 06:55:06 balancerWrapper: is pickfirst: false
INFO: 2018/06/01 06:55:06 grpc: failed dns SRV record lookup due to lookup _grpclb._tcp.localhost on 100.64.0.10:53: no such host.
[...]
```

This PR adds a "wait" for the balancer to have address on the NewGateway function, so when it returns the KiamGateway we ensure there is some address in the balancer