### PR TITLE
setup cache TTL to be 5 minutes before the session expires

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pubnub/go-metrics-statsd"
 	"github.com/rcrowley/go-metrics"
 	log "github.com/sirupsen/logrus"
+	"github.com/uswitch/kiam/pkg/aws/sts"
 	"github.com/uswitch/kiam/pkg/prometheus"
 	serv "github.com/uswitch/kiam/pkg/server"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -68,6 +69,10 @@ func main() {
 
 	if !serverConfig.AutoDetectBaseARN && serverConfig.RoleBaseARN == "" {
 		log.Fatal("role-base-arn not specified and not auto-detected. please specify or use --role-base-arn-autodetect")
+	}
+
+	if serverConfig.SessionDuration < sts.AWSMinSessionDuration {
+		log.Fatal("session-duration should be at least 15 minutes")
 	}
 
 	if flags.jsonLog {

--- a/pkg/aws/sts/credentials.go
+++ b/pkg/aws/sts/credentials.go
@@ -27,7 +27,10 @@ type Credentials struct {
 	LastUpdated     string
 }
 
-const timeLayout = "2006-01-02T15:04:05Z"
+const (
+	timeLayout            = "2006-01-02T15:04:05Z"
+	AWSMinSessionDuration = 15 * time.Minute
+)
 
 func NewCredentials(accessKey, secretKey, token string, expiry time.Time) *Credentials {
 	return &Credentials{


### PR DESCRIPTION
This will set the cacheTTL to sessionDuration - 5 minutes. For the default values Kiam will have the very same behavior, but right now if you increase the sessionDuration the cache is expired after 10 minutes anyway. Solves #44 