### PR TITLE
handle pod roles starting with /

### DIFF
--- a/pkg/aws/sts/arn_resolver.go
+++ b/pkg/aws/sts/arn_resolver.go
@@ -31,6 +31,10 @@ func DefaultResolver(prefix string) *Resolver {
 
 // Resolve converts from a role string into the absolute role arn.
 func (r *Resolver) Resolve(ctx context.Context, role string) (string, error) {
+	if strings.HasPrefix(role, "/") {
+		role = strings.TrimPrefix(role, "/")
+	}
+
 	if strings.HasPrefix(role, "arn:") {
 		return role, nil
 	}

--- a/pkg/k8s/pod_cache.go
+++ b/pkg/k8s/pod_cache.go
@@ -16,7 +16,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	metrics "github.com/rcrowley/go-metrics"
@@ -194,7 +193,7 @@ func (s *PodCache) Run(ctx context.Context) error {
 
 // PodRole returns the IAM role specified in the annotation for the Pod
 func PodRole(pod *v1.Pod) string {
-	return strings.TrimPrefix(pod.ObjectMeta.Annotations[AnnotationIAMRoleKey], "/")
+	return pod.ObjectMeta.Annotations[AnnotationIAMRoleKey]
 }
 
 // AnnotationIAMRoleKey is the key for the annotation specifying the IAM Role

--- a/pkg/k8s/pod_cache.go
+++ b/pkg/k8s/pod_cache.go
@@ -16,6 +16,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	metrics "github.com/rcrowley/go-metrics"
@@ -193,7 +194,7 @@ func (s *PodCache) Run(ctx context.Context) error {
 
 // PodRole returns the IAM role specified in the annotation for the Pod
 func PodRole(pod *v1.Pod) string {
-	return pod.ObjectMeta.Annotations[AnnotationIAMRoleKey]
+	return strings.TrimPrefix(pod.ObjectMeta.Annotations[AnnotationIAMRoleKey], "/")
 }
 
 // AnnotationIAMRoleKey is the key for the annotation specifying the IAM Role

--- a/pkg/server/policy.go
+++ b/pkg/server/policy.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/uswitch/kiam/pkg/k8s"
 	pb "github.com/uswitch/kiam/proto"
@@ -110,7 +111,8 @@ func (p *RequestingAnnotatedRolePolicy) IsAllowedAssumeRole(ctx context.Context,
 		return nil, err
 	}
 
-	annotatedRole := k8s.PodRole(pod)
+	annotatedRole := strings.TrimPrefix(k8s.PodRole(pod), "/")
+
 	if annotatedRole != role {
 		return &forbidden{requested: role, annotated: annotatedRole}, nil
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -160,7 +160,7 @@ func NewServer(config *Config) (*KiamServer, error) {
 	credentialsCache := sts.DefaultCache(stsGateway, config.SessionName, config.SessionDuration, arnResolver)
 	server.credentialsProvider = credentialsCache
 	server.manager = prefetch.NewManager(credentialsCache, server.pods, server.pods)
-	server.assumePolicy = Policies(NewRequestingAnnotatedRolePolicy(server.pods), NewNamespacePermittedRoleNamePolicy(server.namespaces, server.pods))
+	server.assumePolicy = Policies(NewRequestingAnnotatedRolePolicy(server.pods, arnResolver), NewNamespacePermittedRoleNamePolicy(server.namespaces, server.pods))
 
 	certificate, err := tls.LoadX509KeyPair(config.TLS.ServerCert, config.TLS.ServerKey)
 	if err != nil {

--- a/test/functional/metadata_server_test.go
+++ b/test/functional/metadata_server_test.go
@@ -42,7 +42,8 @@ func TestParseAddress(t *testing.T) {
 }
 
 func newWebServer(finder *testutil.StubFinder, creds sts.CredentialsProvider) (*metadata.Server, error) {
-	policy := server.Policies(server.NewRequestingAnnotatedRolePolicy(finder))
+	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
+	policy := server.Policies(server.NewRequestingAnnotatedRolePolicy(finder, arnResolver))
 	return metadata.NewWebServer(defaultConfig(), finder, creds, policy)
 }
 

--- a/test/unit/arn_resolver_test.go
+++ b/test/unit/arn_resolver_test.go
@@ -29,11 +29,27 @@ func TestAddsPrefix(t *testing.T) {
 	}
 }
 
-func TestAddsPrefixWithSlash(t *testing.T) {
+func TestAddsPrefixWithRoleBeginningWithSlash(t *testing.T) {
 	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
 	role, _ := resolver.Resolve(context.Background(), "/myrole")
 
 	if role != "arn:aws:iam::account-id:role/myrole" {
+		t.Error("unexpected role, was:", role)
+	}
+}
+func TestAddsPrefixWithRoleBeginningWithPathWithoutSlash(t *testing.T) {
+	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
+	role, _ := resolver.Resolve(context.Background(), "kiam/myrole")
+
+	if role != "arn:aws:iam::account-id:role/kiam/myrole" {
+		t.Error("unexpected role, was:", role)
+	}
+}
+func TestAddsPrefixWithRoleBeginningWithSlashPath(t *testing.T) {
+	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
+	role, _ := resolver.Resolve(context.Background(), "/kiam/myrole")
+
+	if role != "arn:aws:iam::account-id:role/kiam/myrole" {
 		t.Error("unexpected role, was:", role)
 	}
 }

--- a/test/unit/arn_resolver_test.go
+++ b/test/unit/arn_resolver_test.go
@@ -29,6 +29,15 @@ func TestAddsPrefix(t *testing.T) {
 	}
 }
 
+func TestAddsPrefixWithSlash(t *testing.T) {
+	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
+	role, _ := resolver.Resolve(context.Background(), "/myrole")
+
+	if role != "arn:aws:iam::account-id:role/myrole" {
+		t.Error("unexpected role, was:", role)
+	}
+}
+
 func TestUsesAbsoluteARN(t *testing.T) {
 	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
 	role, _ := resolver.Resolve(context.Background(), "arn:aws:iam::some-other-account:role/another-role")

--- a/test/unit/policy_test.go
+++ b/test/unit/policy_test.go
@@ -36,7 +36,57 @@ func TestRequestedRolePolicy(t *testing.T) {
 		t.Error("role was same, should have been permitted:", decision.Explanation())
 	}
 
+	policy = server.NewRequestingAnnotatedRolePolicy(f)
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !decision.IsAllowed() {
+		t.Error("role was same, should have been permitted:", decision.Explanation())
+	}
+
 	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", "192.168.0.1")
+	if decision.IsAllowed() {
+		t.Error("role is different, should be denied", decision.Explanation())
+	}
+
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", "192.168.0.1")
+	if decision.IsAllowed() {
+		t.Error("role is different, should be denied", decision.Explanation())
+	}
+}
+
+func TestRequestedRolePolicyWithSlash(t *testing.T) {
+	p := testutil.NewPodWithRole("namespace", "name", "192.168.0.1", testutil.PhaseRunning, "/myrole")
+	f := testutil.NewStubFinder(p)
+
+	policy := server.NewRequestingAnnotatedRolePolicy(f)
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !decision.IsAllowed() {
+		t.Error("role was same, should have been permitted:", decision.Explanation())
+	}
+
+	policy = server.NewRequestingAnnotatedRolePolicy(f)
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !decision.IsAllowed() {
+		t.Error("role was same, should have been permitted:", decision.Explanation())
+	}
+
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", "192.168.0.1")
+	if decision.IsAllowed() {
+		t.Error("role is different, should be denied", decision.Explanation())
+	}
+
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", "192.168.0.1")
 	if decision.IsAllowed() {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
@@ -54,6 +104,16 @@ func TestErrorWhenPodNotFound(t *testing.T) {
 	if err != k8s.ErrPodNotFound {
 		t.Error("wrong message", err.Error())
 	}
+
+	_, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
+	if err == nil {
+		t.Error("no pod found, should have been error")
+	}
+
+	if err != k8s.ErrPodNotFound {
+		t.Error("wrong message", err.Error())
+	}
+
 }
 
 func TestNamespacePolicy(t *testing.T) {
@@ -72,7 +132,59 @@ func TestNamespacePolicy(t *testing.T) {
 		t.Errorf("expected to be allowed- pod in correct namespace")
 	}
 
+	policy = server.NewNamespacePermittedRoleNamePolicy(nf, pf)
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !decision.IsAllowed() {
+		t.Errorf("expected to be allowed- pod in correct namespace")
+	}
+
 	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", "192.168.0.1")
+	if decision.IsAllowed() {
+		t.Errorf("expected to be forbidden- requesting role that fails regexp")
+	}
+
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", "192.168.0.1")
+	if decision.IsAllowed() {
+		t.Errorf("expected to be forbidden- requesting role that fails regexp")
+	}
+}
+
+func TestNamespacePolicyWithSlash(t *testing.T) {
+	n := testutil.NewNamespace("red", "^red.*$")
+	nf := testutil.NewNamespaceFinder(n)
+	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
+	pf := testutil.NewStubFinder(p)
+
+	policy := server.NewNamespacePermittedRoleNamePolicy(nf, pf)
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !decision.IsAllowed() {
+		t.Errorf("expected to be allowed- pod in correct namespace")
+	}
+
+	policy = server.NewNamespacePermittedRoleNamePolicy(nf, pf)
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !decision.IsAllowed() {
+		t.Errorf("expected to be allowed- pod in correct namespace")
+	}
+
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", "192.168.0.1")
+	if decision.IsAllowed() {
+		t.Errorf("expected to be forbidden- requesting role that fails regexp")
+	}
+
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", "192.168.0.1")
 	if decision.IsAllowed() {
 		t.Errorf("expected to be forbidden- requesting role that fails regexp")
 	}
@@ -86,6 +198,34 @@ func TestNotAllowedWithoutNamespaceAnnotation(t *testing.T) {
 
 	policy := server.NewNamespacePermittedRoleNamePolicy(nf, pf)
 	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+
+	if decision.IsAllowed() {
+		t.Error("expected failure, empty namespace policy annotation")
+	}
+
+	policy = server.NewNamespacePermittedRoleNamePolicy(nf, pf)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+
+	if decision.IsAllowed() {
+		t.Error("expected failure, empty namespace policy annotation")
+	}
+}
+
+func TestNotAllowedWithoutNamespaceAnnotationWithSlash(t *testing.T) {
+	n := testutil.NewNamespace("red", "")
+	nf := testutil.NewNamespaceFinder(n)
+	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
+	pf := testutil.NewStubFinder(p)
+
+	policy := server.NewNamespacePermittedRoleNamePolicy(nf, pf)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+
+	if decision.IsAllowed() {
+		t.Error("expected failure, empty namespace policy annotation")
+	}
+
+	policy = server.NewNamespacePermittedRoleNamePolicy(nf, pf)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
 
 	if decision.IsAllowed() {
 		t.Error("expected failure, empty namespace policy annotation")


### PR DESCRIPTION
Should be 100% backwards compatible. builded and tested in my staging cluster and it accepts pod roles with leading / and does what i expect it to :)

Closes https://github.com/uswitch/kiam/issues/75