### PR TITLE
resolver: simplify interface

### DIFF
--- a/pkg/aws/sts/arn_resolver.go
+++ b/pkg/aws/sts/arn_resolver.go
@@ -14,7 +14,6 @@
 package sts
 
 import (
-	"context"
 	"fmt"
 	"strings"
 )
@@ -30,14 +29,14 @@ func DefaultResolver(prefix string) *Resolver {
 }
 
 // Resolve converts from a role string into the absolute role arn.
-func (r *Resolver) Resolve(ctx context.Context, role string) (string, error) {
+func (r *Resolver) Resolve(role string) string {
 	if strings.HasPrefix(role, "/") {
 		role = strings.TrimPrefix(role, "/")
 	}
 
 	if strings.HasPrefix(role, "arn:") {
-		return role, nil
+		return role
 	}
 
-	return fmt.Sprintf("%s%s", r.prefix, role), nil
+	return fmt.Sprintf("%s%s", r.prefix, role)
 }

--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -110,11 +110,7 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, role string) 
 	c.meterCacheMiss.Mark(1)
 
 	issue := func() (interface{}, error) {
-		arn, err := c.arnResolver.Resolve(ctx, role)
-		if err != nil {
-			return nil, err
-		}
-
+		arn := c.arnResolver.Resolve(role)
 		credentials, err := c.gateway.Issue(ctx, arn, c.sessionName, c.sessionDuration)
 		if err != nil {
 			metrics.GetOrRegisterMeter("credentialsCache.errorIssuing", metrics.DefaultRegistry).Mark(1)

--- a/pkg/aws/sts/interfaces.go
+++ b/pkg/aws/sts/interfaces.go
@@ -28,5 +28,5 @@ type CredentialsCache interface {
 
 // ARNResolver encapsulates resolution of roles into ARNs.
 type ARNResolver interface {
-	Resolve(ctx context.Context, role string) (string, error)
+	Resolve(role string) string
 }

--- a/pkg/server/policy.go
+++ b/pkg/server/policy.go
@@ -112,8 +112,8 @@ func (p *RequestingAnnotatedRolePolicy) IsAllowedAssumeRole(ctx context.Context,
 		return nil, err
 	}
 
-	annotatedRole, _ := p.resolver.Resolve(ctx, k8s.PodRole(pod))
-	role, _ = p.resolver.Resolve(ctx, role)
+	annotatedRole := p.resolver.Resolve(k8s.PodRole(pod))
+	role = p.resolver.Resolve(role)
 
 	if annotatedRole != role {
 		return &forbidden{requested: role, annotated: annotatedRole}, nil

--- a/test/unit/arn_resolver_test.go
+++ b/test/unit/arn_resolver_test.go
@@ -14,7 +14,6 @@
 package kiam
 
 import (
-	"context"
 	"testing"
 
 	"github.com/uswitch/kiam/pkg/aws/sts"
@@ -22,7 +21,7 @@ import (
 
 func TestAddsPrefix(t *testing.T) {
 	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
-	role, _ := resolver.Resolve(context.Background(), "myrole")
+	role := resolver.Resolve("myrole")
 
 	if role != "arn:aws:iam::account-id:role/myrole" {
 		t.Error("unexpected role, was:", role)
@@ -31,7 +30,7 @@ func TestAddsPrefix(t *testing.T) {
 
 func TestAddsPrefixWithRoleBeginningWithSlash(t *testing.T) {
 	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
-	role, _ := resolver.Resolve(context.Background(), "/myrole")
+	role := resolver.Resolve("/myrole")
 
 	if role != "arn:aws:iam::account-id:role/myrole" {
 		t.Error("unexpected role, was:", role)
@@ -39,7 +38,7 @@ func TestAddsPrefixWithRoleBeginningWithSlash(t *testing.T) {
 }
 func TestAddsPrefixWithRoleBeginningWithPathWithoutSlash(t *testing.T) {
 	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
-	role, _ := resolver.Resolve(context.Background(), "kiam/myrole")
+	role := resolver.Resolve("kiam/myrole")
 
 	if role != "arn:aws:iam::account-id:role/kiam/myrole" {
 		t.Error("unexpected role, was:", role)
@@ -47,7 +46,7 @@ func TestAddsPrefixWithRoleBeginningWithPathWithoutSlash(t *testing.T) {
 }
 func TestAddsPrefixWithRoleBeginningWithSlashPath(t *testing.T) {
 	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
-	role, _ := resolver.Resolve(context.Background(), "/kiam/myrole")
+	role := resolver.Resolve("/kiam/myrole")
 
 	if role != "arn:aws:iam::account-id:role/kiam/myrole" {
 		t.Error("unexpected role, was:", role)
@@ -56,7 +55,7 @@ func TestAddsPrefixWithRoleBeginningWithSlashPath(t *testing.T) {
 
 func TestUsesAbsoluteARN(t *testing.T) {
 	resolver := sts.DefaultResolver("arn:aws:iam::account-id:role/")
-	role, _ := resolver.Resolve(context.Background(), "arn:aws:iam::some-other-account:role/another-role")
+	role := resolver.Resolve("arn:aws:iam::some-other-account:role/another-role")
 
 	if role != "arn:aws:iam::some-other-account:role/another-role" {
 		t.Error("unexpected role, was:", role)


### PR DESCRIPTION
- no errors are returned
- no need for context propagation