### PR TITLE
Add config option for session refresh

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -56,6 +56,7 @@ func main() {
 	kingpin.Flag("role-base-arn-autodetect", "Use EC2 metadata service to detect ARN prefix.").BoolVar(&serverConfig.AutoDetectBaseARN)
 	kingpin.Flag("session", "Session name used when creating STS Tokens.").Default("kiam").StringVar(&serverConfig.SessionName)
 	kingpin.Flag("session-duration", "Requested session duration for STS Tokens.").Default("15m").DurationVar(&serverConfig.SessionDuration)
+	kingpin.Flag("session-refresh", "How soon STS Tokens should be refreshed before their expiration.").Default("5m").DurationVar(&serverConfig.SessionRefresh)
 	kingpin.Flag("assume-role-arn", "IAM Role to assume before processing requests").Default("").StringVar(&serverConfig.AssumeRoleArn)
 
 	kingpin.Flag("cert", "Server certificate path").Required().ExistingFileVar(&serverConfig.TLS.ServerCert)

--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -46,13 +46,19 @@ const (
 	DefaultPurgeInterval = 1 * time.Minute
 )
 
-func DefaultCache(gateway STSGateway, sessionName string, sessionDuration time.Duration, resolver ARNResolver) *credentialsCache {
+func DefaultCache(
+	gateway STSGateway,
+	sessionName string,
+	sessionDuration time.Duration,
+	sessionRefresh time.Duration,
+	resolver ARNResolver,
+) *credentialsCache {
 	c := &credentialsCache{
 		arnResolver:     resolver,
 		expiring:        make(chan *RoleCredentials, 1),
 		sessionName:     fmt.Sprintf("kiam-%s", sessionName),
 		sessionDuration: sessionDuration,
-		cacheTTL:        sessionDuration - 5*time.Minute,
+		cacheTTL:        sessionDuration - sessionRefresh,
 		meterCacheHit:   metrics.GetOrRegisterMeter("credentialsCache.cacheHit", metrics.DefaultRegistry),
 		meterCacheMiss:  metrics.GetOrRegisterMeter("credentialsCache.cacheMiss", metrics.DefaultRegistry),
 		gateway:         gateway,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,6 +39,7 @@ type Config struct {
 	PodSyncInterval          time.Duration
 	SessionName              string
 	SessionDuration          time.Duration
+	SessionRefresh           time.Duration
 	RoleBaseARN              string
 	AutoDetectBaseARN        bool
 	TLS                      *TLSConfig
@@ -157,7 +158,12 @@ func NewServer(config *Config) (*KiamServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	credentialsCache := sts.DefaultCache(stsGateway, config.SessionName, config.SessionDuration, arnResolver)
+	credentialsCache := sts.DefaultCache(
+		stsGateway, config.SessionName,
+		config.SessionDuration,
+		config.SessionRefresh,
+		arnResolver,
+	)
 	server.credentialsProvider = credentialsCache
 	server.manager = prefetch.NewManager(credentialsCache, server.pods, server.pods)
 	server.assumePolicy = Policies(NewRequestingAnnotatedRolePolicy(server.pods, arnResolver), NewNamespacePermittedRoleNamePolicy(server.namespaces, server.pods))

--- a/test/unit/credentials_cache_test.go
+++ b/test/unit/credentials_cache_test.go
@@ -35,7 +35,7 @@ func (s *stubGateway) Issue(ctx context.Context, roleARN, sessionName string, ex
 
 func TestRequestsCredentialsFromGatewayWithEmptyCache(t *testing.T) {
 	stubGateway := &stubGateway{c: &sts.Credentials{Code: "foo"}}
-	cache := sts.DefaultCache(stubGateway, "session", 15*time.Minute, sts.DefaultResolver("prefix:"))
+	cache := sts.DefaultCache(stubGateway, "session", 15*time.Minute, 5*time.Minute, sts.DefaultResolver("prefix:"))
 	ctx := context.Background()
 
 	creds, _ := cache.CredentialsForRole(ctx, "role")


### PR DESCRIPTION
By default, Kiam will refresh credentials if they're set to expire within the next 5 minutes. This is fine for most AWS clients, as they'll also refresh credentials if they're going to expire in the next 5 minutes. However, some legacy AWS clients have more aggressive refresh behavior (https://docs.aws.amazon.com/AWSRubySDK/latest/AWS/Core/CredentialProviders/EC2Provider.html#credentials-instance_method). 

If cached credentials are served to these clients within the time window in which they'll refresh credentials, the clients could thrash requesting new credentials.

This also enables people to disable the cache by setting the refresh window greater than or equal to the `sessionDuration`.

This PR:
- Adds new CLI option for session refresh
- Passes that refresh through to cache