### PR TITLE
metadata server: redirect security-credentials when no trailing slash

### DIFF
--- a/pkg/aws/metadata/handler_role_name.go
+++ b/pkg/aws/metadata/handler_role_name.go
@@ -40,7 +40,7 @@ func trailingSlashSuffixRedirectHandler(rw http.ResponseWriter, req *http.Reques
 	}
 
 	u.Path = fmt.Sprintf("%s/", u.Path)
-	http.Redirect(rw, req, u.String(), http.StatusTemporaryRedirect)
+	http.Redirect(rw, req, u.String(), http.StatusPermanentRedirect)
 }
 
 func (h *roleHandler) Install(router *mux.Router) {

--- a/pkg/aws/metadata/handler_role_name_test.go
+++ b/pkg/aws/metadata/handler_role_name_test.go
@@ -19,7 +19,7 @@ func TestRedirectsToCanonicalPath(t *testing.T) {
 	handler := newHandler(nil)
 	handler.ServeHTTP(rr, r)
 
-	if rr.Code != http.StatusTemporaryRedirect {
+	if rr.Code != http.StatusPermanentRedirect {
 		t.Error("expected redirect, was", rr.Code)
 	}
 }

--- a/pkg/aws/metadata/handler_role_name_test.go
+++ b/pkg/aws/metadata/handler_role_name_test.go
@@ -12,6 +12,18 @@ import (
 	"time"
 )
 
+func TestRedirectsToCanonicalPath(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials", nil)
+	rr := httptest.NewRecorder()
+
+	handler := newHandler(nil)
+	handler.ServeHTTP(rr, r)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Error("expected redirect, was", rr.Code)
+	}
+}
+
 func TestReturnRoleWhenClientResponds(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/", nil)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
This addresses #116: canonical redirect.

Previously we served on both:

* `/{version}/meta-data/iam/security-credentials/`
* `/{version}/meta-data/iam/security-credentials`

This changes so that the latter is redirected to the former.