### PR TITLE
Add support for static role aliases

### DIFF
--- a/cmd/kiam/server.go
+++ b/cmd/kiam/server.go
@@ -57,6 +57,11 @@ func (o *serverOptions) bind(parser parser) {
 	parser.Flag("session-duration", "Requested session duration for STS Tokens.").Default("15m").DurationVar(&o.SessionDuration)
 	parser.Flag("session-refresh", "How soon STS Tokens should be refreshed before their expiration.").Default("5m").DurationVar(&o.SessionRefresh)
 	parser.Flag("assume-role-arn", "IAM Role to assume before processing requests").Default("").StringVar(&o.AssumeRoleArn)
+
+	if o.RoleAliases == nil {
+		o.RoleAliases = map[string]string{}
+	}
+	parser.Flag("role-alias", "Mapping of a role alias to the full role name. e.g., external-dns=stack-12345-external-dns-123456. Can be specified multiple times.").StringMapVar(&o.RoleAliases)
 }
 
 func (opts *serverCommand) Run() {

--- a/pkg/k8s/pod_cache_test.go
+++ b/pkg/k8s/pod_cache_test.go
@@ -35,7 +35,7 @@ func TestFindsRunningPod(t *testing.T) {
 	defer cancel()
 
 	source := kt.NewFakeControllerSource()
-	c := NewPodCache(source, time.Second, bufferSize)
+	c := NewPodCache(source, NewRoleMapper(nil), time.Second, bufferSize)
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Failed", "failed_role"))
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
 	c.Run(ctx)
@@ -54,7 +54,7 @@ func TestFindRoleActive(t *testing.T) {
 	defer cancel()
 
 	source := kt.NewFakeControllerSource()
-	c := NewPodCache(source, time.Second, bufferSize)
+	c := NewPodCache(source, NewRoleMapper(nil), time.Second, bufferSize)
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Failed", "failed_role"))
 	source.Modify(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Failed", "running_role"))
 	source.Modify(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
@@ -78,7 +78,7 @@ func BenchmarkFindPodsByIP(b *testing.B) {
 	defer cancel()
 
 	source := kt.NewFakeControllerSource()
-	c := NewPodCache(source, time.Second, bufferSize)
+	c := NewPodCache(source, NewRoleMapper(nil), time.Second, bufferSize)
 	for i := 0; i < 1000; i++ {
 		source.Add(testutil.NewPodWithRole("ns", fmt.Sprintf("name-%d", i), fmt.Sprintf("ip-%d", i), "Running", "foo_role"))
 	}
@@ -105,7 +105,7 @@ func BenchmarkIsActiveRole(b *testing.B) {
 		role := i % 100
 		source.Add(testutil.NewPodWithRole("ns", fmt.Sprintf("name-%d", i), fmt.Sprintf("ip-%d", i), "Running", fmt.Sprintf("role-%d", role)))
 	}
-	c := NewPodCache(source, time.Second, bufferSize)
+	c := NewPodCache(source, NewRoleMapper(nil), time.Second, bufferSize)
 	c.Run(ctx)
 
 	b.StartTimer()

--- a/pkg/k8s/role_mapper.go
+++ b/pkg/k8s/role_mapper.go
@@ -1,0 +1,39 @@
+package k8s
+
+import "k8s.io/api/core/v1"
+
+// AnnotationIAMRoleKey is the key for the annotation specifying the IAM Role
+const AnnotationIAMRoleKey = "iam.amazonaws.com/role"
+
+// AnnotationIAMRoleAliasKey is the key for the annotation specifying the IAM
+// Role Alias. RoleMapper will map the role alias to the full role name.
+const AnnotationIAMRoleAliasKey = "iam.amazonaws.com/role-alias"
+
+// RoleMapper maps a pod to the role it is configured to assume. It supports
+// role aliases.
+type RoleMapper struct {
+	// A map of role aliases to the full role name
+	aliases map[string]string
+}
+
+// NewRoleMapper creates a new role mapper with the given set of role aliases
+func NewRoleMapper(aliases map[string]string) *RoleMapper {
+	return &RoleMapper{
+		aliases: aliases,
+	}
+}
+
+// PodRole returns the IAM role specified in the annotation for the Pod
+func (m *RoleMapper) PodRole(pod *v1.Pod) string {
+	role, ok := pod.ObjectMeta.Annotations[AnnotationIAMRoleKey]
+	if ok {
+		return role
+	}
+
+	alias, ok := pod.ObjectMeta.Annotations[AnnotationIAMRoleAliasKey]
+	if ok {
+		return m.aliases[alias]
+	}
+
+	return ""
+}

--- a/pkg/k8s/role_mapper_test.go
+++ b/pkg/k8s/role_mapper_test.go
@@ -1,0 +1,88 @@
+package k8s
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRoleMapper(t *testing.T) {
+	roleMapper := NewRoleMapper(map[string]string{
+		"external-dns": "stack-12345-external-dns-98765",
+	})
+
+	cases := []struct {
+		description string
+		pod         *v1.Pod
+		expected    string
+	}{
+		{
+			description: "No role",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: "",
+		},
+		{
+			description: "Static role",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"iam.amazonaws.com/role": "static-role",
+					},
+				},
+			},
+			expected: "static-role",
+		},
+		{
+			description: "Aliased role",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"iam.amazonaws.com/role-alias": "external-dns",
+					},
+				},
+			},
+			expected: "stack-12345-external-dns-98765",
+		},
+		{
+			description: "Both static and alias (static takes precedence)",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"iam.amazonaws.com/role":       "static-role",
+						"iam.amazonaws.com/role-alias": "external-dns",
+					},
+				},
+			},
+			expected: "static-role",
+		},
+		{
+			description: "Invalid alias",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"iam.amazonaws.com/role-alias": "invalid",
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			role := roleMapper.PodRole(tc.pod)
+			if role != tc.expected {
+				t.Fatalf("got %v, want %v", role, tc.expected)
+			}
+		})
+	}
+
+}

--- a/pkg/prefetch/manager_test.go
+++ b/pkg/prefetch/manager_test.go
@@ -15,12 +15,14 @@ package prefetch
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/uswitch/kiam/pkg/aws/sts"
+	"github.com/uswitch/kiam/pkg/k8s"
 	kt "github.com/uswitch/kiam/pkg/k8s/testing"
 	"github.com/uswitch/kiam/pkg/statsd"
 	"github.com/uswitch/kiam/pkg/testutil"
-	"testing"
-	"time"
 )
 
 func init() {
@@ -37,7 +39,7 @@ func TestPrefetchRunningPods(t *testing.T) {
 		requestedRoles <- role
 		return &sts.Credentials{}, nil
 	})
-	manager := NewManager(cache, announcer)
+	manager := NewManager(cache, announcer, k8s.NewRoleMapper(nil))
 	go manager.Run(ctx, 1)
 
 	announcer.Announce(testutil.NewPodWithRole("ns", "name", "ip", "Running", "role"))

--- a/pkg/server/policy_test.go
+++ b/pkg/server/policy_test.go
@@ -28,7 +28,7 @@ func TestRequestedRolePolicy(t *testing.T) {
 	f := kt.NewStubFinder(p)
 
 	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
-	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
+	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver, k8s.NewRoleMapper(nil))
 	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -38,7 +38,7 @@ func TestRequestedRolePolicy(t *testing.T) {
 		t.Error("role was same, should have been permitted:", decision.Explanation())
 	}
 
-	policy = NewRequestingAnnotatedRolePolicy(f, arnResolver)
+	policy = NewRequestingAnnotatedRolePolicy(f, arnResolver, k8s.NewRoleMapper(nil))
 	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -64,7 +64,7 @@ func TestRequestedRolePolicyWithSlash(t *testing.T) {
 	p := testutil.NewPodWithRole("namespace", "name", "192.168.0.1", testutil.PhaseRunning, "/myrole")
 	f := kt.NewStubFinder(p)
 
-	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
+	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver, k8s.NewRoleMapper(nil))
 	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -74,7 +74,7 @@ func TestRequestedRolePolicyWithSlash(t *testing.T) {
 		t.Error("role was same, should have been permitted:", decision.Explanation())
 	}
 
-	policy = NewRequestingAnnotatedRolePolicy(f, arnResolver)
+	policy = NewRequestingAnnotatedRolePolicy(f, arnResolver, k8s.NewRoleMapper(nil))
 	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -98,7 +98,7 @@ func TestRequestedRolePolicyWithSlash(t *testing.T) {
 func TestErrorWhenPodNotFound(t *testing.T) {
 	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
 	f := kt.NewStubFinder(nil)
-	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
+	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver, k8s.NewRoleMapper(nil))
 
 	_, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
 	if err == nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -23,7 +23,8 @@ func init() {
 
 func TestReturnsErrorWhenPodNotFound(t *testing.T) {
 	source := kt.NewFakeControllerSource()
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	roleMapper := k8s.NewRoleMapper(nil)
+	podCache := k8s.NewPodCache(source, roleMapper, time.Second, defaultBuffer)
 	server := &KiamServer{pods: podCache}
 
 	_, err := server.GetPodCredentials(context.Background(), &pb.GetPodCredentialsRequest{})
@@ -40,7 +41,8 @@ func TestReturnsPolicyErrorWhenForbidden(t *testing.T) {
 	source := kt.NewFakeControllerSource()
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
 
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	roleMapper := k8s.NewRoleMapper(nil)
+	podCache := k8s.NewPodCache(source, roleMapper, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 	server := &KiamServer{pods: podCache, assumePolicy: &forbidPolicy{}}
 
@@ -58,7 +60,8 @@ func TestReturnsCredentials(t *testing.T) {
 	source := kt.NewFakeControllerSource()
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
 
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	roleMapper := k8s.NewRoleMapper(nil)
+	podCache := k8s.NewPodCache(source, roleMapper, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 	server := &KiamServer{pods: podCache, assumePolicy: &allowPolicy{}, credentialsProvider: &stubCredentialsProvider{accessKey: "A1234"}}
 


### PR DESCRIPTION
Introduces a new command line option, `--role-alias`, which specifies a
mapping from a role alias to a full role name. A pod can then specify a
role alias via the `iam.amazonaws.com/role-alias` and have it resolved
to the full role.

This is primarily useful in cases where the full role differs between
environments, such as when IAM roles are created by CloudFormation.

A future improvement will be to dynamically look up and cache role
aliases in a config map or similar object.

Example:

```
kiam server --role-alias=external-dns=stack-12345-external-dns-98765
```