### PR TITLE
Add ca-certificates to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ ADD . .
 RUN make
 
 FROM alpine:3.8
-RUN apk --no-cache add iptables
+RUN apk --no-cache add iptables ca-certificates
 COPY --from=build /go/src/github.com/uswitch/kiam/bin/kiam-linux-amd64 /kiam
 CMD []


### PR DESCRIPTION
Related: https://github.com/uswitch/kiam/issues/36

`kiam-server` got the following error.
```
kiam-server-522xx kiam-server {"generation.metadata":0,"level":"error","msg":"error warming credentials: RequestError: send request failed\ncaused by: Post https://sts.amazonaws.com/: x509: failed to load system roots and no roots provided","pod.iam.role":"masters.k8s.dev.rafflesia.io","pod.name":"test-pod-b7bdb7747-dww85","pod.namespace":"default","pod.status.ip":"100.96.3.7","pod.status.phase":"Running","resource.version":"9615569","time":"2018-09-27T14:39:49Z"}
```

I know that this issue can be solved by mounting host's certificate.
https://github.com/uswitch/kiam/blob/ceb88e190bb9552f76a491dad41fcb5d0ba855b9/deploy/server.yaml#L21-L25

However, the certificate's path depends on host OS (also written in the comment)
It seems better to install the certificate in the docker image.
This eliminates the need to care about the host OS and configure the volume.

Before installing ca-certificates:
```
$ docker images kiam
REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
kiam                latest              b9290ba7f5f4        About a minute ago   50.1MB
```

After installing ca-certificates:
```
$ docker images kiam
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
kiam                latest              3b778a6f07b7        7 seconds ago       50.7MB
```

Image sizes are almost the same.

Thanks.
