### PR TITLE
Missing v3 :-(

### DIFF
--- a/cmd/kiam/agent.go
+++ b/cmd/kiam/agent.go
@@ -29,9 +29,8 @@ type agentCommand struct {
 	telemetryOptions
 	tlsOptions
 	clientOptions
+	*http.ServerOptions
 
-	port          int
-	allowIPQuery  bool
 	iptables      bool
 	hostIP        string
 	hostInterface string
@@ -43,8 +42,11 @@ func (cmd *agentCommand) Bind(parser parser) {
 	cmd.tlsOptions.bind(parser)
 	cmd.clientOptions.bind(parser)
 
-	parser.Flag("port", "HTTP port").Default("3100").IntVar(&cmd.port)
-	parser.Flag("allow-ip-query", "Allow client IP to be specified with ?ip. Development use only.").Default("false").BoolVar(&cmd.allowIPQuery)
+	cmd.ServerOptions = http.DefaultOptions()
+
+	parser.Flag("port", "HTTP port").Default("3100").IntVar(&cmd.ListenPort)
+	parser.Flag("allow-ip-query", "Allow client IP to be specified with ?ip. Development use only.").Default("false").BoolVar(&cmd.AllowIPQuery)
+	parser.Flag("whitelist-route-regexp", "Proxy routes matching this regular expression").Default("^$").RegexpVar(&cmd.WhitelistRouteRegexp)
 
 	parser.Flag("iptables", "Add IPTables rules").Default("false").BoolVar(&cmd.iptables)
 	parser.Flag("host", "Host IP address.").Envar("HOST_IP").Required().StringVar(&cmd.hostIP)
@@ -56,7 +58,7 @@ func (opts *agentCommand) Run() {
 
 	if opts.iptables {
 		log.Infof("configuring iptables")
-		rules := newIPTablesRules(opts.hostIP, opts.port, opts.hostInterface)
+		rules := newIPTablesRules(opts.hostIP, opts.ListenPort, opts.hostInterface)
 		err := rules.Add()
 		if err != nil {
 			log.Fatal("error configuring iptables:", err.Error())
@@ -73,9 +75,6 @@ func (opts *agentCommand) Run() {
 	signal.Notify(stopChan, os.Interrupt)
 	signal.Notify(stopChan, syscall.SIGTERM)
 
-	config := http.NewConfig(opts.port)
-	config.AllowIPQuery = opts.allowIPQuery
-
 	ctxGateway, cancelCtxGateway := context.WithTimeout(context.Background(), opts.timeoutKiamGateway)
 	defer cancelCtxGateway()
 
@@ -85,7 +84,7 @@ func (opts *agentCommand) Run() {
 	}
 	defer gateway.Close()
 
-	server, err := http.NewWebServer(config, gateway)
+	server, err := http.NewWebServer(opts.ServerOptions, gateway)
 	if err != nil {
 		log.Fatalf("error creating agent http server: %s", err.Error())
 	}

--- a/pkg/aws/metadata/client_ip_test.go
+++ b/pkg/aws/metadata/client_ip_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -13,4 +14,8 @@ func TestParseAddress(t *testing.T) {
 	if ip != "127.0.0.1" {
 		t.Error("incorrect ip, was", ip)
 	}
+}
+
+func getBlankClientIP(_ *http.Request) (string, error) {
+	return "", nil
 }

--- a/pkg/aws/metadata/handler_health.go
+++ b/pkg/aws/metadata/handler_health.go
@@ -21,10 +21,16 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uswitch/kiam/pkg/statsd"
+
+	"github.com/gorilla/mux"
 )
 
 type healthHandler struct {
 	endpoint string
+}
+
+func (h *healthHandler) Install(router *mux.Router) {
+	router.Handle("/health", adapt(withMeter("health", h)))
 }
 
 func (h *healthHandler) Handle(ctx context.Context, w http.ResponseWriter, req *http.Request) (int, error) {
@@ -53,4 +59,10 @@ func (h *healthHandler) Handle(ctx context.Context, w http.ResponseWriter, req *
 
 	fmt.Fprint(w, string(body))
 	return http.StatusOK, nil
+}
+
+func newHealthHandler(endpoint string) *healthHandler {
+	return &healthHandler{
+		endpoint: endpoint,
+	}
 }

--- a/pkg/aws/metadata/handler_proxy.go
+++ b/pkg/aws/metadata/handler_proxy.go
@@ -1,0 +1,63 @@
+// Copyright 2017 uSwitch
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/gorilla/mux"
+)
+
+type proxyHandler struct {
+	backingService       http.Handler
+	whitelistRouteRegexp *regexp.Regexp
+}
+
+func (p *proxyHandler) Install(router *mux.Router) {
+	router.Handle("/{path}", adapt(withMeter("proxy", p)))
+}
+
+type teeWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *teeWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (p *proxyHandler) Handle(ctx context.Context, w http.ResponseWriter, r *http.Request) (int, error) {
+	route := mux.Vars(r)["path"]
+	if p.whitelistRouteRegexp.MatchString(route) {
+		writer := &teeWriter{w, http.StatusOK}
+		p.backingService.ServeHTTP(writer, r)
+		return writer.status, nil
+	} else {
+		return http.StatusNotFound, fmt.Errorf("request blocked by whitelist-route-regexp %q: %s", p.whitelistRouteRegexp, route)
+	}
+}
+
+func newProxyHandler(backingService http.Handler, whitelistRouteRegexp *regexp.Regexp) *proxyHandler {
+	if whitelistRouteRegexp.String() == "" {
+		whitelistRouteRegexp = regexp.MustCompile("^$")
+	}
+	return &proxyHandler{
+		backingService:       backingService,
+		whitelistRouteRegexp: whitelistRouteRegexp,
+	}
+}

--- a/pkg/aws/metadata/handler_proxy_test.go
+++ b/pkg/aws/metadata/handler_proxy_test.go
@@ -1,0 +1,107 @@
+// Copyright 2017 uSwitch
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package metadata
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+func TestProxyDefaultBlacklisting(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	var hits int
+	backingService := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := newProxyHandler(backingService, regexp.MustCompile(""))
+	router := mux.NewRouter()
+	handler.Install(router)
+
+	r, _ := http.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, r.WithContext(ctx))
+
+	if hits != 0 {
+		t.Error("unexpected reverse proxy hit")
+	}
+	if rr.Code != http.StatusNotFound {
+		t.Error("unexpected status", rr.Code)
+	}
+}
+
+func TestProxyFiltering(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	allowedRoutes := regexp.MustCompile("foo.*")
+
+	var hits int
+	backingService := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := newProxyHandler(backingService, allowedRoutes)
+	router := mux.NewRouter()
+	handler.Install(router)
+
+	r, _ := http.NewRequest("GET", "/bar", nil)
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, r.WithContext(ctx))
+
+	if hits != 0 {
+		t.Error("unexpected reverse proxy hit")
+	}
+	if rr.Code != http.StatusNotFound {
+		t.Error("unexpected status", rr.Code)
+	}
+}
+
+func TestProxyWhitelisting(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	allowedRoutes := regexp.MustCompile("foo.*")
+
+	var hits int
+	backingService := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := newProxyHandler(backingService, allowedRoutes)
+	router := mux.NewRouter()
+	handler.Install(router)
+
+	r, _ := http.NewRequest("GET", "/foo", nil)
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, r.WithContext(ctx))
+
+	if hits != 1 {
+		t.Error("expected reverse proxy hit")
+	}
+	if rr.Code != http.StatusOK {
+		t.Error("unexpected status", rr.Code)
+	}
+}

--- a/pkg/aws/metadata/handler_role_name.go
+++ b/pkg/aws/metadata/handler_role_name.go
@@ -30,8 +30,8 @@ import (
 )
 
 type roleHandler struct {
-	client   server.Client
-	clientIP clientIPFunc
+	client      server.Client
+	getClientIP clientIPFunc
 }
 
 func trailingSlashSuffixRedirectHandler(rw http.ResponseWriter, req *http.Request) {
@@ -64,7 +64,7 @@ func (h *roleHandler) Handle(ctx context.Context, w http.ResponseWriter, req *ht
 		return http.StatusInternalServerError, err
 	}
 
-	ip, err := h.clientIP(req)
+	ip, err := h.getClientIP(req)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -114,4 +114,11 @@ func findRole(ctx context.Context, client server.Client, ip string) (string, err
 	}
 
 	return <-roleCh, nil
+}
+
+func newRoleHandler(client server.Client, getClientIP clientIPFunc) *roleHandler {
+	return &roleHandler{
+		client:      client,
+		getClientIP: getClientIP,
+	}
 }

--- a/pkg/aws/metadata/handler_role_name_test.go
+++ b/pkg/aws/metadata/handler_role_name_test.go
@@ -3,21 +3,24 @@ package metadata
 import (
 	"context"
 	"fmt"
-	"github.com/gorilla/mux"
-	"github.com/uswitch/kiam/pkg/server"
-	st "github.com/uswitch/kiam/pkg/testutil/server"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/uswitch/kiam/pkg/server"
+	st "github.com/uswitch/kiam/pkg/testutil/server"
 )
 
 func TestRedirectsToCanonicalPath(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials", nil)
 	rr := httptest.NewRecorder()
+	handler := newRoleHandler(nil, nil)
+	router := mux.NewRouter()
+	handler.Install(router)
 
-	handler := newHandler(nil)
-	handler.ServeHTTP(rr, r)
+	router.ServeHTTP(rr, r)
 
 	if rr.Code != http.StatusPermanentRedirect {
 		t.Error("expected redirect, was", rr.Code)
@@ -27,9 +30,11 @@ func TestRedirectsToCanonicalPath(t *testing.T) {
 func TestReturnRoleWhenClientResponds(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/", nil)
 	rr := httptest.NewRecorder()
-	handler := newHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"foo_role", nil}))
+	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"foo_role", nil}), getBlankClientIP)
+	router := mux.NewRouter()
+	handler.Install(router)
 
-	handler.ServeHTTP(rr, r)
+	router.ServeHTTP(rr, r)
 
 	if rr.Code != http.StatusOK {
 		t.Error("expected 200 response, was", rr.Code)
@@ -44,9 +49,11 @@ func TestReturnRoleWhenClientResponds(t *testing.T) {
 func TestReturnRoleWhenRetryingFollowingError(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/", nil)
 	rr := httptest.NewRecorder()
-	handler := newHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", fmt.Errorf("unexpected error")}, st.GetRoleResult{"foo_role", nil}))
+	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", fmt.Errorf("unexpected error")}, st.GetRoleResult{"foo_role", nil}), getBlankClientIP)
+	router := mux.NewRouter()
+	handler.Install(router)
 
-	handler.ServeHTTP(rr, r)
+	router.ServeHTTP(rr, r)
 
 	if rr.Code != http.StatusOK {
 		t.Error("expected 200 response, was", rr.Code)
@@ -61,9 +68,11 @@ func TestReturnRoleWhenRetryingFollowingError(t *testing.T) {
 func TestReturnsEmptyRoleWhenClientSucceedsWithEmptyRole(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/", nil)
 	rr := httptest.NewRecorder()
-	handler := newHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", nil}))
+	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", nil}), getBlankClientIP)
+	router := mux.NewRouter()
+	handler.Install(router)
 
-	handler.ServeHTTP(rr, r)
+	router.ServeHTTP(rr, r)
 
 	if rr.Code != http.StatusNotFound {
 		t.Error("expected 404 response, was", rr.Code)
@@ -76,25 +85,13 @@ func TestReturnErrorWhenPodNotFoundWithinTimeout(t *testing.T) {
 
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/", nil)
 	rr := httptest.NewRecorder()
-	handler := newHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", server.ErrPodNotFound}))
+	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", server.ErrPodNotFound}), getBlankClientIP)
+	router := mux.NewRouter()
+	handler.Install(router)
 
-	handler.ServeHTTP(rr, r.WithContext(ctx))
+	router.ServeHTTP(rr, r.WithContext(ctx))
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Error("expected internal server error, was:", rr.Code)
 	}
-}
-
-func newHandler(c server.Client) http.Handler {
-	ip := func(r *http.Request) (string, error) {
-		return "", nil
-	}
-
-	h := &roleHandler{
-		client:   c,
-		clientIP: ip,
-	}
-	r := mux.NewRouter()
-	h.Install(r)
-	return r
 }

--- a/pkg/aws/metadata/server.go
+++ b/pkg/aws/metadata/server.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -28,25 +29,27 @@ import (
 )
 
 type Server struct {
-	cfg    *ServerConfig
+	cfg    *ServerOptions
 	server *http.Server
 }
 
-type ServerConfig struct {
-	ListenPort       int
-	MetadataEndpoint string
-	AllowIPQuery     bool
+type ServerOptions struct {
+	ListenPort           int
+	MetadataEndpoint     string
+	AllowIPQuery         bool
+	WhitelistRouteRegexp *regexp.Regexp
 }
 
-func NewConfig(port int) *ServerConfig {
-	return &ServerConfig{
-		MetadataEndpoint: "http://169.254.169.254",
-		ListenPort:       port,
-		AllowIPQuery:     false,
+func DefaultOptions() *ServerOptions {
+	return &ServerOptions{
+		MetadataEndpoint:     "http://169.254.169.254",
+		ListenPort:           3100,
+		AllowIPQuery:         false,
+		WhitelistRouteRegexp: regexp.MustCompile("^$"),
 	}
 }
 
-func NewWebServer(config *ServerConfig, client server.Client) (*Server, error) {
+func NewWebServer(config *ServerOptions, client server.Client) (*Server, error) {
 	http, err := buildHTTPServer(config, client)
 	if err != nil {
 		return nil, err
@@ -54,38 +57,33 @@ func NewWebServer(config *ServerConfig, client server.Client) (*Server, error) {
 	return &Server{cfg: config, server: http}, nil
 }
 
-func buildHTTPServer(config *ServerConfig, client server.Client) (*http.Server, error) {
+func buildHTTPServer(config *ServerOptions, client server.Client) (*http.Server, error) {
 	router := mux.NewRouter()
-	router.Handle("/ping", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "pong") }))
 
 	h := &healthHandler{config.MetadataEndpoint}
 	router.Handle("/health", adapt(withMeter("health", h)))
+	router.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "pong") })
+	h.Install(router)
 
-	clientIP := buildClientIP(config)
-
-	r := &roleHandler{
-		client:   client,
-		clientIP: clientIP,
-	}
+	r := newRoleHandler(client, buildClientIP(config))
 	r.Install(router)
 
-	c := &credentialsHandler{
-		clientIP: clientIP,
-		client:   client,
-	}
+	c := newCredentialsHandler(client, buildClientIP(config))
 	c.Install(router)
 
 	metadataURL, err := url.Parse(config.MetadataEndpoint)
 	if err != nil {
 		return nil, err
 	}
-	router.Handle("/{path:.*}", httputil.NewSingleHostReverseProxy(metadataURL))
+
+	p := newProxyHandler(httputil.NewSingleHostReverseProxy(metadataURL), config.WhitelistRouteRegexp)
+	p.Install(router)
 
 	listen := fmt.Sprintf(":%d", config.ListenPort)
 	return &http.Server{Addr: listen, Handler: loggingHandler(router)}, nil
 }
 
-func buildClientIP(config *ServerConfig) clientIPFunc {
+func buildClientIP(config *ServerOptions) clientIPFunc {
 	remote := func(req *http.Request) (string, error) {
 		return ParseClientIP(req.RemoteAddr)
 	}


### PR DESCRIPTION
I was messaged on Slack to point out that the whitelisting path changes added in #110 wasn't available in `master` and also missing from the `v3-rc1` image.

Having checked through history it looks like some later v3 changes were merged but into the previously merged `api-v3` branch but weren't then integrated to master. The missing commit appears to be https://github.com/uswitch/kiam/commit/afdb221cf63de4cdcf2e70f75660c25456103d75.

I cherry picked that commit and went through the merge conflicts; the result is these set of changes.

Note that, because this adds a change- it blocks metadata access by default- the default behaviour will be different. It also means the current `v3-rc1` is missing a key part of the v3 changes which will alter behaviour.