### PR TITLE
Metadata server: Use 301 rather than 308 redirects

### DIFF
--- a/pkg/aws/metadata/handler_role_name.go
+++ b/pkg/aws/metadata/handler_role_name.go
@@ -41,7 +41,7 @@ func trailingSlashSuffixRedirectHandler(rw http.ResponseWriter, req *http.Reques
 	}
 
 	u.Path = fmt.Sprintf("%s/", u.Path)
-	http.Redirect(rw, req, u.String(), http.StatusPermanentRedirect)
+	http.Redirect(rw, req, u.String(), http.StatusMovedPermanently)
 }
 
 func (h *roleHandler) Install(router *mux.Router) {

--- a/pkg/aws/metadata/handler_role_name_test.go
+++ b/pkg/aws/metadata/handler_role_name_test.go
@@ -23,7 +23,7 @@ func TestRedirectsToCanonicalPath(t *testing.T) {
 
 	router.ServeHTTP(rr, r)
 
-	if rr.Code != http.StatusPermanentRedirect {
+	if rr.Code != http.StatusMovedPermanently {
 		t.Error("expected redirect, was", rr.Code)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/uswitch/kiam/issues/172. Tested and confirmed that this allows the Go SDK version 1.4.10 to retrieve credentials from kiam.