### PR TITLE
Allow kiam-write to send events to pods

### DIFF
--- a/deploy/server-rbac.yaml
+++ b/deploy/server-rbac.yaml
@@ -44,6 +44,7 @@ rules:
   - events
   verbs:
   - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
So that kiam can send events to pods about authentication failures, expiry and others.

Without this permission the following will be seen in the kiam-server logs;

```'events "pod.156488d50955a61a" is forbidden: User "system:serviceaccount:kube-system:kiam-server" cannot patch events in the namespace "default"' (will not retry!)```