### PR TITLE
Fix race condition with xtables.lock

### DIFF
--- a/deploy/agent.yaml
+++ b/deploy/agent.yaml
@@ -29,6 +29,7 @@ spec:
         - name: xtables
           hostPath:
             path: /run/xtables.lock
+            type: FileOrCreate
       containers:
         - name: kiam
           securityContext:


### PR DESCRIPTION
This change fixes a race condition on the `/run/xtables.lock` file.  If KIAM starts, but the `/run/xtables.lock` file is not present, docker will create it as a directory.  kube-proxy then fails to create a lockfile with the same name and crashes.  This renders the node inoperable.

We were experiencing an increase in node failures after rolling KIAM out to our test lab and after troubleshooting, found this to be the issue.  This issue can be seen in other software that uses the `/run/xtables.lock` file, like weavenet: https://github.com/weaveworks/weave/pull/3353

Basically, the path to a node being inoperable was like this:
- KIAM crashes
- KIAM restarts
- docker attempts to mount /run/xtables.lock, but as a directory
- the directory does not exist, and neither does the lock file, so docker creates it as a directory
- kube-proxy runs another iptables operation
- kube-proxy is unable to lock the `/run/xtables.lock` file because it is a directory
- kube-proxy crashes
- kube-proxy repeatedly crashes and is unable to start
- the node is unable to provision new pods

I would like to note that our open source monitoring software, [kuberhealthy](https://github.com/Comcast/kuberhealthy) made it possible for us to detect this issue.  Had we just been deleting "failed" nodes, we may have never found the root cause.