### PR TITLE
Fix KIAM cache miss metric name on dashboard

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -47,8 +47,8 @@ daemonset status from kube-state-metrics & container metrics from cAdvisor if av
 
 #### STS Subsystem
 
-- `cache_hit_total` - Number of cache hits to the metadata cache
-- `cache_miss_total` - Number of cache misses to the metadata cache
+- `kiam_sts_cache_hit_total` - Number of cache hits to the metadata cache
+- `kiam_sts_cache_miss_total` - Number of cache misses to the metadata cache
 - `issuing_errors_total` - Number of errors issuing credentials
 - `assumerole_timing_milliseconds` - Bucketed histogram of assumeRole timings
 - `assumerole_current` - Number of assume role calls currently executing

--- a/docs/dashboard-prom.json
+++ b/docs/dashboard-prom.json
@@ -910,7 +910,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (delta(kiam_sts_cache_miss_total_total[$interval])) by (pod)",
+          "expr": "sum (delta(kiam_sts_cache_miss_total[$interval])) by (pod)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{pod}}",


### PR DESCRIPTION
This metric is called `kiam_sts_cache_miss_total` as I see in Prometheus. I think you even have this bug on a dashboard screenshot in a doc (cache miss has no data there because metric name in json is incorrect). Here's my dashboard after I updated it:
![image](https://user-images.githubusercontent.com/5246026/48956270-d4bc3780-ef5a-11e8-92f6-e786db27edaa.png)
