### PR TITLE
Testing: Add leaktest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -74,6 +74,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/fortytw2/leaktest"
+  packages = ["."]
+  revision = "9a23578d06a26ec1b47bfc8965bf5e7011df8bd6"
+  version = "v1.3.0"
+
+[[projects]]
   name = "github.com/ghodss/yaml"
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
@@ -552,6 +558,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e1b58ad2381a3b37a0a8e9ec23910610d0d803d97145324b45885f6fb9a94fc4"
+  inputs-digest = "b4579c4afb897651187b6fd07319642665ccf1641c0af462e6fe3feced576c75"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -96,3 +96,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/fortytw2/leaktest"
+  version = "1.3.0"

--- a/pkg/aws/metadata/handler_credentials_test.go
+++ b/pkg/aws/metadata/handler_credentials_test.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"encoding/json"
+	"github.com/fortytw2/leaktest"
 	"github.com/gorilla/mux"
 	"github.com/uswitch/kiam/pkg/aws/sts"
 	"github.com/uswitch/kiam/pkg/server"
@@ -22,6 +23,7 @@ func init() {
 func TestReturnsCredentials(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
+	defer leaktest.Check(t)()
 
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/role", nil)
 	rr := httptest.NewRecorder()
@@ -60,6 +62,7 @@ func TestReturnsCredentials(t *testing.T) {
 func TestReturnsErrorWithNoPod(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
+	defer leaktest.Check(t)()
 
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/role", nil)
 	rr := httptest.NewRecorder()
@@ -82,6 +85,7 @@ func TestReturnsErrorWithNoPod(t *testing.T) {
 func TestReturnsCredentialsWithRetryAfterError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
+	defer leaktest.Check(t)()
 
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/role", nil)
 	rr := httptest.NewRecorder()

--- a/pkg/aws/metadata/handler_role_name_test.go
+++ b/pkg/aws/metadata/handler_role_name_test.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"github.com/fortytw2/leaktest"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uswitch/kiam/pkg/server"
@@ -14,6 +15,8 @@ import (
 )
 
 func TestRedirectsToCanonicalPath(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials", nil)
 	rr := httptest.NewRecorder()
 
@@ -48,6 +51,8 @@ func readPrometheusCounterValue(name, labelName, labelValue string) float64 {
 }
 
 func TestIncrementsPrometheusCounter(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/", nil)
 	rr := httptest.NewRecorder()
 
@@ -68,6 +73,8 @@ func TestIncrementsPrometheusCounter(t *testing.T) {
 }
 
 func TestReturnRoleWhenClientResponds(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/", nil)
 	rr := httptest.NewRecorder()
 	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"foo_role", nil}), getBlankClientIP)
@@ -87,6 +94,8 @@ func TestReturnRoleWhenClientResponds(t *testing.T) {
 }
 
 func TestReturnRoleWhenRetryingFollowingError(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/", nil)
 	rr := httptest.NewRecorder()
 	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", fmt.Errorf("unexpected error")}, st.GetRoleResult{"foo_role", nil}), getBlankClientIP)
@@ -106,6 +115,8 @@ func TestReturnRoleWhenRetryingFollowingError(t *testing.T) {
 }
 
 func TestReturnsEmptyRoleWhenClientSucceedsWithEmptyRole(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	r, _ := http.NewRequest("GET", "/latest/meta-data/iam/security-credentials/", nil)
 	rr := httptest.NewRecorder()
 	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", nil}), getBlankClientIP)
@@ -120,6 +131,8 @@ func TestReturnsEmptyRoleWhenClientSucceedsWithEmptyRole(t *testing.T) {
 }
 
 func TestReturnErrorWhenPodNotFoundWithinTimeout(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 

--- a/pkg/future/future_test.go
+++ b/pkg/future/future_test.go
@@ -15,11 +15,14 @@ package future
 
 import (
 	"context"
+	"github.com/fortytw2/leaktest"
 	"testing"
 	"time"
 )
 
 func TestReturnsValue(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	f := New(func() (interface{}, error) {
 		return "hello", nil
 	})
@@ -37,6 +40,8 @@ func TestReturnsValue(t *testing.T) {
 }
 
 func TestCancelsWhenBlocked(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	f := New(func() (interface{}, error) {
 		time.Sleep(1 * time.Second)
 		return "bar", nil

--- a/pkg/prefetch/manager_test.go
+++ b/pkg/prefetch/manager_test.go
@@ -15,6 +15,7 @@ package prefetch
 
 import (
 	"context"
+	"github.com/fortytw2/leaktest"
 	"github.com/uswitch/kiam/pkg/aws/sts"
 	kt "github.com/uswitch/kiam/pkg/k8s/testing"
 	"github.com/uswitch/kiam/pkg/statsd"
@@ -28,6 +29,8 @@ func init() {
 }
 
 func TestPrefetchRunningPods(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/fortytw2/leaktest"
 	"github.com/uswitch/kiam/pkg/aws/sts"
 	"github.com/uswitch/kiam/pkg/k8s"
 	"github.com/uswitch/kiam/pkg/statsd"
@@ -37,7 +38,11 @@ func TestErrorSimplification(t *testing.T) {
 }
 
 func TestReturnsErrorWhenPodNotFound(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	source := kt.NewFakeControllerSource()
+	defer source.Shutdown()
+
 	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
 	server := &KiamServer{pods: podCache}
 
@@ -49,10 +54,13 @@ func TestReturnsErrorWhenPodNotFound(t *testing.T) {
 }
 
 func TestReturnsPolicyErrorWhenForbidden(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	source := kt.NewFakeControllerSource()
+	defer source.Shutdown()
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
 
 	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
@@ -67,10 +75,13 @@ func TestReturnsPolicyErrorWhenForbidden(t *testing.T) {
 }
 
 func TestReturnsCredentials(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	source := kt.NewFakeControllerSource()
+	defer source.Shutdown()
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
 
 	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)

--- a/vendor/github.com/fortytw2/leaktest/.travis.yml
+++ b/vendor/github.com/fortytw2/leaktest/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+go:
+ - 1.8
+ - 1.9
+ - "1.10"
+ - "1.11"
+ - tip
+
+script:
+ - go test -v -race -parallel 5 -coverprofile=coverage.txt -covermode=atomic ./
+ - go test github.com/fortytw2/leaktest -run ^TestEmptyLeak$
+
+before_install:
+  - pip install --user codecov
+after_success:
+  - codecov

--- a/vendor/github.com/fortytw2/leaktest/LICENSE
+++ b/vendor/github.com/fortytw2/leaktest/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/fortytw2/leaktest/README.md
+++ b/vendor/github.com/fortytw2/leaktest/README.md
@@ -1,0 +1,64 @@
+## Leaktest [![Build Status](https://travis-ci.org/fortytw2/leaktest.svg?branch=master)](https://travis-ci.org/fortytw2/leaktest) [![codecov](https://codecov.io/gh/fortytw2/leaktest/branch/master/graph/badge.svg)](https://codecov.io/gh/fortytw2/leaktest) [![Sourcegraph](https://sourcegraph.com/github.com/fortytw2/leaktest/-/badge.svg)](https://sourcegraph.com/github.com/fortytw2/leaktest?badge) [![Documentation](https://godoc.org/github.com/fortytw2/gpt?status.svg)](http://godoc.org/github.com/fortytw2/leaktest)
+
+Refactored, tested variant of the goroutine leak detector found in both
+`net/http` tests and the `cockroachdb` source tree.
+
+Takes a snapshot of running goroutines at the start of a test, and at the end -
+compares the two and _voila_. Ignores runtime/sys goroutines. Doesn't play nice
+with `t.Parallel()` right now, but there are plans to do so.
+
+### Installation
+
+Go 1.7+
+
+```
+go get -u github.com/fortytw2/leaktest
+```
+
+Go 1.5/1.6 need to use the tag `v1.0.0`, as newer versions depend on
+`context.Context`.
+
+### Example
+
+These tests fail, because they leak a goroutine
+
+```go
+// Default "Check" will poll for 5 seconds to check that all
+// goroutines are cleaned up
+func TestPool(t *testing.T) {
+    defer leaktest.Check(t)()
+
+    go func() {
+        for {
+            time.Sleep(time.Second)
+        }
+    }()
+}
+
+// Helper function to timeout after X duration
+func TestPoolTimeout(t *testing.T) {
+    defer leaktest.CheckTimeout(t, time.Second)()
+
+    go func() {
+        for {
+            time.Sleep(time.Second)
+        }
+    }()
+}
+
+// Use Go 1.7+ context.Context for cancellation
+func TestPoolContext(t *testing.T) {
+    ctx, _ := context.WithTimeout(context.Background(), time.Second)
+    defer leaktest.CheckContext(ctx, t)()
+
+    go func() {
+        for {
+            time.Sleep(time.Second)
+        }
+    }()
+}
+```
+
+## LICENSE
+
+Same BSD-style as Go, see LICENSE

--- a/vendor/github.com/fortytw2/leaktest/leaktest.go
+++ b/vendor/github.com/fortytw2/leaktest/leaktest.go
@@ -1,0 +1,153 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package leaktest provides tools to detect leaked goroutines in tests.
+// To use it, call "defer leaktest.Check(t)()" at the beginning of each
+// test that may use goroutines.
+// copied out of the cockroachdb source tree with slight modifications to be
+// more re-useable
+package leaktest
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type goroutine struct {
+	id    uint64
+	stack string
+}
+
+type goroutineByID []*goroutine
+
+func (g goroutineByID) Len() int           { return len(g) }
+func (g goroutineByID) Less(i, j int) bool { return g[i].id < g[j].id }
+func (g goroutineByID) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
+
+func interestingGoroutine(g string) (*goroutine, error) {
+	sl := strings.SplitN(g, "\n", 2)
+	if len(sl) != 2 {
+		return nil, fmt.Errorf("error parsing stack: %q", g)
+	}
+	stack := strings.TrimSpace(sl[1])
+	if strings.HasPrefix(stack, "testing.RunTests") {
+		return nil, nil
+	}
+
+	if stack == "" ||
+		// Ignore HTTP keep alives
+		strings.Contains(stack, ").readLoop(") ||
+		strings.Contains(stack, ").writeLoop(") ||
+		// Below are the stacks ignored by the upstream leaktest code.
+		strings.Contains(stack, "testing.Main(") ||
+		strings.Contains(stack, "testing.(*T).Run(") ||
+		strings.Contains(stack, "runtime.goexit") ||
+		strings.Contains(stack, "created by runtime.gc") ||
+		strings.Contains(stack, "interestingGoroutines") ||
+		strings.Contains(stack, "runtime.MHeap_Scavenger") ||
+		strings.Contains(stack, "signal.signal_recv") ||
+		strings.Contains(stack, "sigterm.handler") ||
+		strings.Contains(stack, "runtime_mcall") ||
+		strings.Contains(stack, "goroutine in C code") {
+		return nil, nil
+	}
+
+	// Parse the goroutine's ID from the header line.
+	h := strings.SplitN(sl[0], " ", 3)
+	if len(h) < 3 {
+		return nil, fmt.Errorf("error parsing stack header: %q", sl[0])
+	}
+	id, err := strconv.ParseUint(h[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing goroutine id: %s", err)
+	}
+
+	return &goroutine{id: id, stack: strings.TrimSpace(g)}, nil
+}
+
+// interestingGoroutines returns all goroutines we care about for the purpose
+// of leak checking. It excludes testing or runtime ones.
+func interestingGoroutines(t ErrorReporter) []*goroutine {
+	buf := make([]byte, 2<<20)
+	buf = buf[:runtime.Stack(buf, true)]
+	var gs []*goroutine
+	for _, g := range strings.Split(string(buf), "\n\n") {
+		gr, err := interestingGoroutine(g)
+		if err != nil {
+			t.Errorf("leaktest: %s", err)
+			continue
+		} else if gr == nil {
+			continue
+		}
+		gs = append(gs, gr)
+	}
+	sort.Sort(goroutineByID(gs))
+	return gs
+}
+
+// ErrorReporter is a tiny subset of a testing.TB to make testing not such a
+// massive pain
+type ErrorReporter interface {
+	Errorf(format string, args ...interface{})
+}
+
+// Check snapshots the currently-running goroutines and returns a
+// function to be run at the end of tests to see whether any
+// goroutines leaked, waiting up to 5 seconds in error conditions
+func Check(t ErrorReporter) func() {
+	return CheckTimeout(t, 5*time.Second)
+}
+
+// CheckTimeout is the same as Check, but with a configurable timeout
+func CheckTimeout(t ErrorReporter, dur time.Duration) func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	fn := CheckContext(ctx, t)
+	return func() {
+		timer := time.AfterFunc(dur, cancel)
+		fn()
+		// Remember to clean up the timer and context
+		timer.Stop()
+		cancel()
+	}
+}
+
+// CheckContext is the same as Check, but uses a context.Context for
+// cancellation and timeout control
+func CheckContext(ctx context.Context, t ErrorReporter) func() {
+	orig := map[uint64]bool{}
+	for _, g := range interestingGoroutines(t) {
+		orig[g.id] = true
+	}
+	return func() {
+		var leaked []string
+		for {
+			select {
+			case <-ctx.Done():
+				t.Errorf("leaktest: timed out checking goroutines")
+			default:
+				leaked = make([]string, 0)
+				for _, g := range interestingGoroutines(t) {
+					if !orig[g.id] {
+						leaked = append(leaked, g.stack)
+					}
+				}
+				if len(leaked) == 0 {
+					return
+				}
+				// don't spin needlessly
+				time.Sleep(time.Millisecond * 50)
+				continue
+			}
+			break
+		}
+		for _, g := range leaked {
+			t.Errorf("leaktest: leaked goroutine: %v", g)
+		}
+	}
+}


### PR DESCRIPTION
During a lot of the v3 restructuring we removed leaktest from a bunch of tests. This adds them back.

Our hope was this might reveal something relevant to the recently reported #191. Unfortunately, it doesn't but there are parts of the system that aren't assembled together under the tests that wouldn't have been revealed.

Next steps would be to pick up #108 with leaktest to be more confident.