### PR TITLE
pprof HTTP

### DIFF
--- a/cmd/kiam/opts.go
+++ b/cmd/kiam/opts.go
@@ -16,11 +16,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"time"
-
 	log "github.com/sirupsen/logrus"
+	"github.com/uswitch/kiam/pkg/pprof"
 	"github.com/uswitch/kiam/pkg/prometheus"
 	"github.com/uswitch/kiam/pkg/statsd"
+	"time"
 )
 
 type logOptions struct {
@@ -84,6 +84,12 @@ func (o telemetryOptions) start(ctx context.Context, identifier string) {
 	if o.prometheusListen != "" {
 		metrics := prometheus.NewServer(identifier, o.prometheusListen, o.prometheusSync)
 		metrics.Listen(ctx)
+	}
+
+	if o.pprofListen != "" {
+		log.Infof("pprof listen address specified, will listen on %s", o.pprofListen)
+		server := pprof.NewServer(o.pprofListen)
+		go pprof.ListenAndWait(ctx, server)
 	}
 }
 

--- a/cmd/kiam/opts.go
+++ b/cmd/kiam/opts.go
@@ -56,6 +56,7 @@ type telemetryOptions struct {
 	statsDPrefix     string
 	prometheusListen string
 	prometheusSync   time.Duration
+	pprofListen      string
 }
 
 func (o *telemetryOptions) bind(parser parser) {
@@ -65,6 +66,8 @@ func (o *telemetryOptions) bind(parser parser) {
 
 	parser.Flag("prometheus-listen-addr", "Prometheus HTTP listen address. e.g. localhost:9620").StringVar(&o.prometheusListen)
 	parser.Flag("prometheus-sync-interval", "How frequently to update Prometheus metrics").Default("5s").DurationVar(&o.prometheusSync)
+
+	parser.Flag("pprof-listen-addr", "Address to bind pprof HTTP server. e.g. localhost:9990").Default("").StringVar(&o.pprofListen)
 }
 
 func (o telemetryOptions) start(ctx context.Context, identifier string) {

--- a/cmd/kiam/server.go
+++ b/cmd/kiam/server.go
@@ -21,6 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/uswitch/kiam/pkg/aws/sts"
+	"github.com/uswitch/kiam/pkg/pprof"
 	serv "github.com/uswitch/kiam/pkg/server"
 )
 
@@ -71,6 +72,12 @@ func (opts *serverCommand) Run() {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+
+	if opts.pprofListen != "" {
+		log.Infof("pprof listen address specified, starting http server")
+		server := pprof.NewServer(opts.pprofListen)
+		go pprof.ListenAndWait(ctx, server)
+	}
 
 	opts.telemetryOptions.start(ctx, "server")
 

--- a/cmd/kiam/server.go
+++ b/cmd/kiam/server.go
@@ -21,7 +21,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/uswitch/kiam/pkg/aws/sts"
-	"github.com/uswitch/kiam/pkg/pprof"
 	serv "github.com/uswitch/kiam/pkg/server"
 )
 
@@ -72,12 +71,6 @@ func (opts *serverCommand) Run() {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-
-	if opts.pprofListen != "" {
-		log.Infof("pprof listen address specified, starting http server")
-		server := pprof.NewServer(opts.pprofListen)
-		go pprof.ListenAndWait(ctx, server)
-	}
 
 	opts.telemetryOptions.start(ctx, "server")
 

--- a/pkg/pprof/server.go
+++ b/pkg/pprof/server.go
@@ -1,0 +1,26 @@
+package pprof
+
+import (
+	"context"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	_ "net/http/pprof"
+)
+
+func NewServer(listenAddr string) http.Server {
+	server := http.Server{Addr: listenAddr, Handler: http.DefaultServeMux}
+	return server
+}
+
+// Starts server and shuts down when context signals
+func ListenAndWait(ctx context.Context, server http.Server) {
+	go func() {
+		err := server.ListenAndServe()
+		if err != nil {
+			log.Errorf("error starting pprof http server: %s", err.Error())
+		}
+	}()
+	<-ctx.Done()
+	log.Infof("shutting down pprof server")
+	server.Shutdown(context.Background())
+}


### PR DESCRIPTION
This adds the [net/http/pprof](https://golang.org/pkg/net/http/pprof/) HTTP handler that can be used to pull live dumps from Kiam processes.

I'd like to have this added to diagnose #191 further and see if there is an issue.