### PR TITLE
Disable gRPC service configuration TXT DNS record lookup in kiam agent

### DIFF
--- a/pkg/server/gateway.go
+++ b/pkg/server/gateway.go
@@ -86,6 +86,7 @@ func NewGateway(ctx context.Context, address string, caFile, certificateFile, ke
 		grpc.WithTransportCredentials(creds),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(retry.UnaryClientInterceptor(callOpts...), grpc_prometheus.UnaryClientInterceptor)),
 		grpc.WithBalancerName(roundrobin.Name),
+		grpc.WithDisableServiceConfig(),
 		grpc.WithBlock(),
 		grpc.WithWaitForHandshake(),
 		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),


### PR DESCRIPTION
The _kiam_ server doesn't publish a gRPC service configuration in DNS, and the CoreDNS server used commonly in Kubernetes [doesn't serve these records anyway](https://github.com/coredns/coredns/blob/master/plugin/kubernetes/kubernetes.go#L97-98) (previously mentioned in coredns/coredns#2290), so disable this behavior in the _kiam_ agent's gRPC client.

Fixes #204.
