### PR TITLE
Update server.yaml to allow master taints

### DIFF
--- a/deploy/server.yaml
+++ b/deploy/server.yaml
@@ -17,6 +17,10 @@ spec:
       serviceAccountName: kiam-server
       nodeSelector:
         kubernetes.io/role: master
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"         
       volumes:
         - name: ssl-certs
           hostPath:


### PR DESCRIPTION
The kiam server needs to be schedulable on tainted nodes using a toleration for node-role.kubernetes.io/master