### PR TITLE
update server.json for v3

### DIFF
--- a/docs/server.json
+++ b/docs/server.json
@@ -1,10 +1,8 @@
 {
     "hosts": [
         "kiam-server",
-        "kiam-server:443",
         "127.0.0.1",
-        "127.0.0.1:443",
-        "127.0.0.1:9610"
+        "localhost"
     ],
     "key": {
         "algo": "rsa",


### PR DESCRIPTION
Update server.json to add `localhost` and remove port names.  Not having localhost blew up our spec because we were using `localhost` with the `--server-address` flag.  I believe this flag's setting came from a prior version of something on this site.  Switching this up may help others to avoid our pitfall.