### PR TITLE
add logging level to server.yaml

### DIFF
--- a/deploy/server.yaml
+++ b/deploy/server.yaml
@@ -35,6 +35,7 @@ spec:
           args:
             - server
             - --json-log
+            - --level=info
             - --bind=0.0.0.0:443
             - --cert=/etc/kiam/tls/server.pem
             - --key=/etc/kiam/tls/server-key.pem

--- a/deploy/server.yaml
+++ b/deploy/server.yaml
@@ -35,7 +35,7 @@ spec:
           args:
             - server
             - --json-log
-            - --level=warning
+            - --level=warn
             - --bind=0.0.0.0:443
             - --cert=/etc/kiam/tls/server.pem
             - --key=/etc/kiam/tls/server-key.pem

--- a/deploy/server.yaml
+++ b/deploy/server.yaml
@@ -35,7 +35,7 @@ spec:
           args:
             - server
             - --json-log
-            - --level=info
+            - --level=warning
             - --bind=0.0.0.0:443
             - --cert=/etc/kiam/tls/server.pem
             - --key=/etc/kiam/tls/server-key.pem


### PR DESCRIPTION
A simple flag for debug level in the example will help when admins want to turn the logging up later.