### PR TITLE
build with go 1.11

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,14 +5,14 @@ workspace:
 pipeline:
   test:
     secrets: [ codecov_token ]
-    image: golang:1.10
+    image: golang:1.11
     commands:
       - make test
       - make coverage.txt
       - ./ci/codecov.sh
 
   benchmarks:
-    image: golang:1.10
+    image: golang:1.11
     commands:
       - make bench
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.10-alpine3.8 as build
+FROM golang:1.11-alpine3.9 as build
 RUN apk add --no-cache make
 WORKDIR /go/src/github.com/uswitch/kiam
 ADD . .
 RUN make bin/kiam-linux-amd64
 
-FROM alpine:3.8
+FROM alpine:3.9
 RUN apk --no-cache add iptables
 COPY --from=build /go/src/github.com/uswitch/kiam/bin/kiam-linux-amd64 /kiam
 CMD []


### PR DESCRIPTION
@Joseph-Irving highlighted a recent increase in the probe failures. It seems like this could be related to https://github.com/golang/go/issues/22724 so we'll build a point release on 1.11 to understand more.