### PR TITLE
increment proxy success count metric

### DIFF
--- a/pkg/aws/metadata/handler_proxy.go
+++ b/pkg/aws/metadata/handler_proxy.go
@@ -45,6 +45,10 @@ func (p *proxyHandler) Handle(ctx context.Context, w http.ResponseWriter, r *htt
 	if p.whitelistRouteRegexp.MatchString(r.URL.Path) {
 		writer := &teeWriter{w, http.StatusOK}
 		p.backingService.ServeHTTP(writer, r)
+
+		if writer.status == http.StatusOK {
+			success.WithLabelValues("proxy").Inc()
+		}
 		return writer.status, nil
 	}
 


### PR DESCRIPTION
This will increment `kiam_metadata_success_total` when requests through the proxy succeed

Also added a test to check that the proxy propagates the response code from the metadata-api.