### PR TITLE
Pod cache should only be watching running pods

### DIFF
--- a/pkg/k8s/listwatch.go
+++ b/pkg/k8s/listwatch.go
@@ -15,5 +15,5 @@ const (
 
 // NewListWatch creates a ListWatch for the specified Resource
 func NewListWatch(client *kubernetes.Clientset, resource string) *cache.ListWatch {
-	return cache.NewListWatchFromClient(client.Core().RESTClient(), resource, "", fields.Everything())
+	return cache.NewListWatchFromClient(client.Core().RESTClient(), resource, "", fields.OneTermEqualSelector("status.phase", "Running"))
 }


### PR DESCRIPTION
We see the following error on our clusters because k8s starts reusing the ips from pods stuck in pending state: "error finding pod: multiple running pods found"

shouldn't it be looking at running pods only?
