### PR TITLE
Treat ErrPolicyForbidden and ErrPodNotFound as permanent errors during retry backoff

### DIFF
--- a/pkg/aws/metadata/handler_credentials.go
+++ b/pkg/aws/metadata/handler_credentials.go
@@ -78,9 +78,10 @@ func (c *credentialsHandler) fetchCredentials(ctx context.Context, ip, requested
 		creds, err := c.client.GetCredentials(ctx, ip, requestedRole)
 		if err != nil {
 			if grpcStatus, ok := status.FromError(err); ok {
-				if grpcStatus.Message() == server.ErrPolicyForbidden.Error() {
+				switch grpcStatus.Message() {
+				case server.ErrPolicyForbidden.Error():
 					return backoff.Permanent(server.ErrPolicyForbidden)
-				} else if grpcStatus.Message() == server.ErrPodNotFound.Error() {
+				case server.ErrPodNotFound.Error():
 					return backoff.Permanent(server.ErrPodNotFound)
 				}
 			}

--- a/pkg/aws/metadata/handler_credentials.go
+++ b/pkg/aws/metadata/handler_credentials.go
@@ -78,8 +78,10 @@ func (c *credentialsHandler) fetchCredentials(ctx context.Context, ip, requested
 		creds, err := c.client.GetCredentials(ctx, ip, requestedRole)
 		if err != nil {
 			if grpcStatus, ok := status.FromError(err); ok {
-				if grpcStatus.Message() == server.ErrPolicyForbidden.Error() || grpcStatus.Message() == server.ErrPolicyForbidden.Error() {
-					return backoff.Permanent(err)
+				if grpcStatus.Message() == server.ErrPolicyForbidden.Error() {
+					return backoff.Permanent(server.ErrPolicyForbidden)
+				} else if grpcStatus.Message() == server.ErrPodNotFound.Error() {
+					return backoff.Permanent(server.ErrPodNotFound)
 				}
 			}
 

--- a/pkg/aws/metadata/handler_credentials.go
+++ b/pkg/aws/metadata/handler_credentials.go
@@ -75,6 +75,9 @@ func (c *credentialsHandler) fetchCredentials(ctx context.Context, ip, requested
 	op := func() error {
 		creds, err := c.client.GetCredentials(ctx, ip, requestedRole)
 		if err != nil {
+			if err == server.ErrPolicyForbidden || err == server.ErrPodNotFound {
+				return backoff.Permanent(err)
+			}
 			return err
 		}
 		credsCh <- creds

--- a/pkg/aws/metadata/handler_credentials.go
+++ b/pkg/aws/metadata/handler_credentials.go
@@ -81,8 +81,6 @@ func (c *credentialsHandler) fetchCredentials(ctx context.Context, ip, requested
 				switch grpcStatus.Message() {
 				case server.ErrPolicyForbidden.Error():
 					return backoff.Permanent(server.ErrPolicyForbidden)
-				case server.ErrPodNotFound.Error():
-					return backoff.Permanent(server.ErrPodNotFound)
 				}
 			}
 


### PR DESCRIPTION
If a pod requests credentials it's not allowed to, kiam-agent will keep retrying the same request until the five second timeout is reached.  This changeset treats ErrPolicyForbidden (as well as ErrPodNotFound) as permanent errors, so that the AWS client talking to kiam-agent gets a response in a more timely fashion.