### PR TITLE
Updated to include increase verbosity on credential chain errors.

### DIFF
--- a/pkg/aws/sts/gateway.go
+++ b/pkg/aws/sts/gateway.go
@@ -81,7 +81,7 @@ type DefaultSTSGateway struct {
 }
 
 func DefaultGateway(assumeRoleArn, region string) (*DefaultSTSGateway, error) {
-	config := aws.NewConfig()
+        config := aws.NewConfig().WithCredentialsChainVerboseErrors(true)
 	if assumeRoleArn != "" {
 		config.WithCredentials(stscreds.NewCredentials(session.Must(session.NewSession()), assumeRoleArn))
 	}


### PR DESCRIPTION
The AWS SDK  does a lot of awesome things to get a set of credentials for you but at the same time this can make it tricky to figure out exactly what is happening. Setting the AWS Config with CredentialsChainVerboseErrors set to true can make troubleshooting NoCredentialsChain errors alot easier as it spells out in the error what it tried and what didn't work.