### PR TITLE
Update Dockerfile to include ca-certificates

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ workspace:
 pipeline:
   test:
     secrets: [ codecov_token ]
-    image: golang:1.13
+    image: golang:1.15
     environment:
       GO111MODULE: "on"
     commands:
@@ -14,7 +14,7 @@ pipeline:
       - ./ci/codecov.sh
 
   benchmarks:
-    image: golang:1.13
+    image: golang:1.15
     environment:
       GO111MODULE: "on"
     commands:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-buster as build
+FROM golang:1.15.7 as build
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM golang:1.13.8 as build
-ENV GO111MODULE=on
+FROM golang:1.15.7-buster as build
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,7 +15,13 @@ COPY Makefile Makefile
 
 RUN make bin/kiam-linux-amd64
 
-FROM alpine:3.11
-RUN apk --no-cache add iptables
-COPY --from=build /workspace/bin/kiam-linux-amd64 /kiam
-CMD []
+FROM alpine:3.13
+
+COPY --from=build /workspace/bin/kiam-linux-amd64 /usr/local/bin/kiam
+
+RUN apk --no-cache add \
+    ca-certificates \
+    iptables \
+    && update-ca-certificates
+
+ENTRYPOINT ["kiam"]


### PR DESCRIPTION
* Update to Golang v1.15.7 base image
* Update final base image to Alpine v3.13
* Add ca-certificates to final build image. Required for communicating with the AWS API.
* Formatting changes. 

Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>