### PR TITLE
return empty string if resolver passed empty role

### DIFF
--- a/pkg/aws/sts/arn_resolver.go
+++ b/pkg/aws/sts/arn_resolver.go
@@ -30,6 +30,10 @@ func DefaultResolver(prefix string) *Resolver {
 
 // Resolve converts from a role string into the absolute role arn.
 func (r *Resolver) Resolve(role string) string {
+	if role == "" {
+		return ""
+	}
+
 	if strings.HasPrefix(role, "/") {
 		role = strings.TrimPrefix(role, "/")
 	}

--- a/pkg/aws/sts/arn_resolver_test.go
+++ b/pkg/aws/sts/arn_resolver_test.go
@@ -26,6 +26,15 @@ func TestAddsPrefix(t *testing.T) {
 	}
 }
 
+func TestReturnsEmpty(t *testing.T) {
+	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
+	role := resolver.Resolve("")
+
+	if role != "" {
+		t.Error("unexpected role, was:", role)
+	}
+}
+
 func TestAddsPrefixWithRoleBeginningWithSlash(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
 	role := resolver.Resolve("/myrole")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -33,7 +33,7 @@ import (
 	pb "github.com/uswitch/kiam/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"k8s.io/api/core/v1"	
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"


### PR DESCRIPTION
https://github.com/uswitch/kiam/pull/276 introduced a bug if you don't set assume-role-arn

`arnResolver.Resolve(config.AssumeRoleArn)` returns something like `arn:aws:iam::xxxxxxxxx:role/` when passed an empty assume role arn, which prevents the Default Gateway from using the instance role, it instead trys to assume this non existent role.

So I've changed `arnResolver.Resolve` to return "" if the role is empty, restoring the old behaviour