### PR TITLE
_helpers.tpl: Correctly render port number for certificates

### DIFF
--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 2.5.2
+version: 2.5.3
 appVersion: 3.3
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/templates/_helpers.tpl
+++ b/helm/kiam/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Generate certificates for kiam server and agent
 {{.Values.agent.tlsCerts.keyFileName }}: {{ $cert.Key | b64enc }}
 {{- end -}}
 {{- define "kiam.server.gen-certs" -}}
-{{- $altNames := list (include "kiam.server.fullname" .) (printf "%s:%d" (include "kiam.server.fullname" .) .Values.server.service.port) (printf "127.0.0.1:%d" .Values.server.service.targetPort) -}}
+{{- $altNames := list (include "kiam.server.fullname" .) (printf "%s:%d" (include "kiam.server.fullname" .) (int64 .Values.server.service.port)) (printf "127.0.0.1:%d" (int64 .Values.server.service.targetPort)) -}}
 {{- $ca := .ca | default (genCA "kiam-ca" 365) -}}
 {{- $_ := set . "ca" $ca -}}
 {{- $cert := genSignedCert "Kiam Server" (list "127.0.0.1") $altNames 365 $ca -}}


### PR DESCRIPTION
The datatype of `.Values.server.service.port` is float64 by default. So `printf "127.0.0.1:%d" .Values.server.service.targetPort` will be evaluated into below:

    127.0.0.1:%!d(float64=443)

We need to cast `.Values.server.service.port` into integer type before using it.

##### References:
- https://helm.sh/docs/chart_best_practices/#make-types-clear
- https://github.com/helm/charts/pull/16561