### PR TITLE
Enable passing of default role-filtering expression.

### DIFF
--- a/cmd/kiam/server.go
+++ b/cmd/kiam/server.go
@@ -58,7 +58,7 @@ func (o *serverOptions) bind(parser parser) {
 	parser.Flag("session-refresh", "How soon STS Tokens should be refreshed before their expiration.").Default("5m").DurationVar(&o.SessionRefresh)
 	parser.Flag("assume-role-arn", "IAM Role to assume before processing requests").Default("").StringVar(&o.AssumeRoleArn)
 	parser.Flag("region", "AWS Region to use for regional STS calls (e.g. us-west-2). Defaults to the global endpoint.").Default("").StringVar(&o.Region)
-	parser.Flag("allow-all-namespace-roles", "").BoolVar(&o.AnyNamespaceRole)
+	parser.Flag("role-pattern-default", "Role filtering pattern used when not defined in namespace").Default("").StringVar(&o.RolePatternDefault)
 }
 
 func (opts *serverCommand) Run() {

--- a/cmd/kiam/server.go
+++ b/cmd/kiam/server.go
@@ -58,6 +58,7 @@ func (o *serverOptions) bind(parser parser) {
 	parser.Flag("session-refresh", "How soon STS Tokens should be refreshed before their expiration.").Default("5m").DurationVar(&o.SessionRefresh)
 	parser.Flag("assume-role-arn", "IAM Role to assume before processing requests").Default("").StringVar(&o.AssumeRoleArn)
 	parser.Flag("region", "AWS Region to use for regional STS calls (e.g. us-west-2). Defaults to the global endpoint.").Default("").StringVar(&o.Region)
+	parser.Flag("allow-all-namespace-roles", "").BoolVar(&o.AnyNamespaceRole)
 }
 
 func (opts *serverCommand) Run() {

--- a/helm/kiam/templates/server-daemonset.yaml
+++ b/helm/kiam/templates/server-daemonset.yaml
@@ -87,8 +87,8 @@ spec:
             - --prometheus-listen-addr=0.0.0.0:{{ .Values.server.prometheus.port }}
             - --prometheus-sync-interval={{ .Values.server.prometheus.syncInterval }}
             {{- end }}
-            {{- if .Values.server.allowAllNamespaceRoles }}
-            - --allow-all-namespace-roles
+            {{- if .Values.server.rolePatternDefault }}
+            - --role-pattern-default={{ .Values.server.rolePatternDefault }}
             {{- end }}
           {{- range $key, $value := .Values.server.extraArgs }}
             {{- if $value }}

--- a/helm/kiam/templates/server-daemonset.yaml
+++ b/helm/kiam/templates/server-daemonset.yaml
@@ -87,6 +87,9 @@ spec:
             - --prometheus-listen-addr=0.0.0.0:{{ .Values.server.prometheus.port }}
             - --prometheus-sync-interval={{ .Values.server.prometheus.syncInterval }}
             {{- end }}
+            {{- if .Values.server.allowAllNamespaceRoles }}
+            - --allow-all-namespace-roles
+            {{- end }}
           {{- range $key, $value := .Values.server.extraArgs }}
             {{- if $value }}
             - --{{ $key }}={{ $value }}

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -256,9 +256,9 @@ server:
   ## Use hostNetwork for server
   ## Set this to true when running the servers on the same nodes as the agents
   useHostNetwork: false
-  ## Set this to true, if you do not want to filter permitted roles per namespace
+  ## Default role-name pattern used if undefined in namespace
   ## Facilitates migration from kube2iam: https://github.com/uswitch/kiam/issues/188
-  allowAllNamespaceRoles: false
+  rolePatternDefault: null
 
   ## Agent TLS Certificate filenames
   tlsCerts:

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -256,6 +256,9 @@ server:
   ## Use hostNetwork for server
   ## Set this to true when running the servers on the same nodes as the agents
   useHostNetwork: false
+  ## Set this to true, if you do not want to filter permitted roles per namespace
+  ## Facilitates migration from kube2iam: https://github.com/uswitch/kiam/issues/188
+  allowAllNamespaceRoles: false
 
   ## Agent TLS Certificate filenames
   tlsCerts:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -56,7 +56,7 @@ type Config struct {
 	PrefetchBufferSize       int
 	AssumeRoleArn            string
 	Region                   string
-	AnyNamespaceRole				 bool
+	RolePatternDefault        string
 }
 
 // TLSConfig controls TLS
@@ -253,11 +253,7 @@ func NewServer(config *Config) (*KiamServer, error) {
 	server.credentialsProvider = credentialsCache
 	server.manager = prefetch.NewManager(credentialsCache, server.pods)
 
-	if config.AnyNamespaceRole {
-		server.assumePolicy = Policies(NewRequestingAnnotatedRolePolicy(server.pods, arnResolver))
-	} else {
-		server.assumePolicy = Policies(NewRequestingAnnotatedRolePolicy(server.pods, arnResolver), NewNamespacePermittedRoleNamePolicy(server.namespaces, server.pods))
-	}
+	server.assumePolicy = Policies(NewRequestingAnnotatedRolePolicy(server.pods, arnResolver), NewNamespacePermittedRoleNamePolicy(server.namespaces, server.pods, config.RolePatternDefault))
 
 	certificate, err := tls.LoadX509KeyPair(config.TLS.ServerCert, config.TLS.ServerKey)
 	if err != nil {


### PR DESCRIPTION
A key step and inhibitor in migrating from Kube2IAM to Kiam is adding role-filtering patterns to each namespace of interest - e.g. #188. 

This change adds an option to enable the supplying of a default pattern, for use when the pattern is not defined in any given namespace.

The option has been named _'role-pattern-default'_, but feel free to request changes to this.