### PR TITLE
Change Helm extraEnv parameters to array

### DIFF
--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Helm Chart Changelog
+## 3.0.0
+4 September 2019
+
+Notable Changes:
+* The `extraEnv` parameters in `values.yaml` have been changed to support an array of options.
+
+## 2.5.3
+29 August 2019
+
+Notable Changes:
+* [#288](https://github.com/uswitch/kiam/pull/288) Bug fix for correctly rendering port number for certificates.
+
+Many thanks to the following contributor for this release:
+* [@simnalamburt](https://github.com/simnalamburt)
+
+## 2.5.2
+27 August 2019
+
+Notable Changes:
+* [#285](https://github.com/uswitch/kiam/pull/285) and [#287](https://github.com/uswitch/kiam/pull/287) Chart is updated to include uSwitch logo.
+
+## 2.5.1
+20 August 2019
+
+Notable Changes:
+* [#283](https://github.com/uswitch/kiam/pull/283) Kiam Helm charts are added to the [uswitch/kiam](https://github.com/uswitch/kiam) repo.

--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -2,8 +2,9 @@
 ## 3.0.0
 4 September 2019
 
-Notable Changes:
-* The `extraEnv` parameters in `values.yaml` have been changed to support an array of options.
+<b>BREAKING CHANGES</b>:
+* [#292](https://github.com/uswitch/kiam/pull/292) The `extraEnv` parameters for both the agent and server in `values.yaml` have been changed to support an array of options. This adds support for creating env vars from configMaps or secretKeyRefs.</br>
+`Note:` This will break any existing Helm deployments which utilise the `extraEnv` parameters in `values.yaml`. You will need to update your `values.yaml` file to match the format in the [template](/helm/kiam/values.yaml#L93)
 
 ## 2.5.3
 29 August 2019

--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 2.5.3
+version: 3.0.0
 appVersion: 3.3
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -92,7 +92,15 @@ agent:
   extraArgs: {}
   ## Additional container environment variables
   ##
-  extraEnv: {}
+
+  # - name: VARNAME1
+  #   value: value1
+  # - name: VARNAME2
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: existing-secret
+  #       key: varname2-key
+  extraEnv: []
 
   ## Additional container hostPath mounts
   ##
@@ -203,7 +211,15 @@ server:
   extraArgs: {}
   ## Additional container environment variables
   ##
-  extraEnv: {}
+
+  # - name: VARNAME1
+  #   value: value1
+  # - name: VARNAME2
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: existing-secret
+  #       key: varname2-key
+  extraEnv: []
 
   ## Additional container hostPath mounts
   ##


### PR DESCRIPTION
* Fix #289 - Update extraEnv parameters to arrays, allowing env vars to be created from configmaps and secrets, as well as key:value pairs
* Fix #286 - Create changelog to track Helm chart changes