### PR TITLE
Set chart gatewayTimeoutCreation to project deployment defaults

### DIFF
--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 3.0.0
+version: 3.1.0
 appVersion: 3.3
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -115,7 +115,7 @@ agent:
 
   ## Timeout when creating the kiam gateway
   ##
-  gatewayTimeoutCreation: 50ms
+  gatewayTimeoutCreation: 1s
 
   ## Base64-encoded PEM values for agent's CA certificate(s), certificate and private key
   ##
@@ -238,7 +238,7 @@ server:
 
   ## Timeout when creating the kiam gateway
   ##
-  gatewayTimeoutCreation: 50ms
+  gatewayTimeoutCreation: 1s
 
   ## Server probe configuration
   probes:


### PR DESCRIPTION
Migrated from [helm/charts!16369](https://github.com/helm/charts/pull/16369).

The Helm chart default of 50ms can cause pods to restart randomly on
start-up, exacerbated by any CPU throttling or resource limits. The
[default set in the project manifests](https://github.com/uswitch/kiam/blob/04e66a7203457ada3b2dfb2efd0e9fdc50ea9260/deploy/agent.yaml#L56) is 1s.