### PR TITLE
Fix helm templates

### DIFF
--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Helm Chart Changelog
+## 3.0.1
+10 September 2019
+
+Notable Changes:
+* [#295](https://github.com/uswitch/kiam/pull/295) <b>BUG FIX</b> - The Kiam server and agent daemonset files have been updated to account for the change to the `values.yaml` file made in [#292](https://github.com/uswitch/kiam/pull/292). Without this change, users will experience issues when deploying the v3 release of the Chart with the extraEnv parameters set in `values.yaml`.
+
 ## 3.0.0
-4 September 2019
+5 September 2019
 
 <b>BREAKING CHANGES</b>:
 * [#292](https://github.com/uswitch/kiam/pull/292) The `extraEnv` parameters for both the agent and server in `values.yaml` have been changed to support an array of options. This adds support for creating env vars from configMaps or secretKeyRefs.</br>

--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 3.0.0
+version: 3.0.1
 appVersion: 3.3
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/templates/agent-daemonset.yaml
+++ b/helm/kiam/templates/agent-daemonset.yaml
@@ -111,10 +111,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-          {{- range $name, $value := .Values.agent.extraEnv }}
-            - name: {{ $name }}
-              value: {{ quote $value }}
-          {{- end }}
+          {{- if .Values.agent.extraEnv }}
+{{ toYaml .Values.agent.extraEnv | indent 12 }}
+        {{- end }}
           volumeMounts:
             - mountPath: /etc/kiam/tls
               name: tls

--- a/helm/kiam/templates/server-daemonset.yaml
+++ b/helm/kiam/templates/server-daemonset.yaml
@@ -94,12 +94,9 @@ spec:
             - --{{ $key }}
             {{- end }}
           {{- end }}
-        {{- if .Values.server.extraEnv }}
           env:
-          {{- range $name, $value := .Values.server.extraEnv }}
-            - name: {{ $name }}
-              value: {{ quote $value }}
-          {{- end }}
+          {{- if .Values.server.extraEnv }}
+{{ toYaml .Values.server.extraEnv | indent 12 }}
         {{- end }}
           volumeMounts:
             - mountPath: /etc/kiam/tls


### PR DESCRIPTION
* Fix required for the recently implemented extraEnv parameters as arrays feature. Updated template files so examples seen in values.yaml are correct.