### PR TITLE
agent: fix #229: ensure deferred funcs run + cleanup

### DIFF
--- a/cmd/kiam/agent.go
+++ b/cmd/kiam/agent.go
@@ -103,7 +103,6 @@ func (opts *agentCommand) run() error {
 	go func() {
 		errCh <- server.Serve()
 	}()
-	defer server.Stop(ctx)
 
 	select {
 	case err := <-errCh:
@@ -112,7 +111,12 @@ func (opts *agentCommand) run() error {
 			return err
 		}
 	case sig := <-stopChan:
-		log.Infof("received signal (%s) stopping now", sig.String())
+		log.Infof("received signal (%s): starting server shutdown", sig.String())
+		if err := server.Stop(ctx); err != nil {
+			log.Errorf("error shutting down server: %s", err.Error())
+			return err
+		}
+		log.Infoln("gracefully shutdown server")
 	}
 	log.Infoln("stopped")
 	return nil

--- a/pkg/aws/metadata/server.go
+++ b/pkg/aws/metadata/server.go
@@ -105,12 +105,10 @@ func (s *Server) Serve() error {
 	return s.server.ListenAndServe()
 }
 
-func (s *Server) Stop(ctx context.Context) {
-	log.Infoln("starting server shutdown")
+func (s *Server) Stop(ctx context.Context) error {
 	c, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	s.server.Shutdown(c)
-	log.Infoln("gracefully shutdown server")
+	return s.server.Shutdown(c)
 }
 
 func ParseClientIP(addr string) (string, error) {


### PR DESCRIPTION
This fixes [#229](https://github.com/uswitch/kiam/issues/299) while also cleaning up the run logic to catch the error returned by server.Serve() and log when iptables changes are being undone.

This also changes the agent to handle server shutdown directly in the `run()` command and log any errors.  Previously, the code relied on a deferred call to `Stop()` and errors were ignored.