### PR TITLE
Update default kiam in helm chart to 3.4

### DIFF
--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Helm Chart Changelog
+
+## 3.1.0
+07 October 2019
+
+Notable Changes:
+* Update kiam release from 3.3 to 3.4
+
 ## 3.0.1
 10 September 2019
 

--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -4,7 +4,7 @@
 07 October 2019
 
 Notable Changes:
-* Update kiam release from 3.3 to 3.4
+* [#304](https://github.com/uswitch/kiam/pull/304) Update kiam release from 3.3 to 3.4
 
 ## 3.0.1
 10 September 2019

--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kiam
-version: 3.0.1
-appVersion: 3.3
+version: 3.1.0
+appVersion: 3.4
 description: Integrate AWS IAM with Kubernetes
 keywords:
   - kiam

--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -99,7 +99,7 @@ Parameter | Description | Default
 `agent.enabled` | If true, create agent | `true`
 `agent.name` | Agent container name | `agent`
 `agent.image.repository` | Agent image | `quay.io/uswitch/kiam`
-`agent.image.tag` | Agent image tag | `v3.3`
+`agent.image.tag` | Agent image tag | `v3.4`
 `agent.image.pullPolicy` | Agent image pull policy | `IfNotPresent`
 `agent.dnsPolicy` | Agent pod DNS policy | `ClusterFirstWithHostNet`
 `agent.whiteListRouteRegexp` | Agent pod whitelist metadata API path argument regex  | `{}`
@@ -134,7 +134,7 @@ Parameter | Description | Default
 `server.name` | Server container name | `server`
 `server.gatewayTimeoutCreation` | Server's timeout when creating the kiam gateway | `50ms`
 `server.image.repository` | Server image | `quay.io/uswitch/kiam`
-`server.image.tag` | Server image tag | `v3.3`
+`server.image.tag` | Server image tag | `v3.4`
 `server.image.pullPolicy` | Server image pull policy | `Always`
 `server.assumeRoleArn` | IAM role for the server to assume before processing requests | `null`
 `server.cache.syncInterval` | Pod cache synchronization interval | `1m`

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -11,7 +11,7 @@ agent:
 
   image:
     repository: quay.io/uswitch/kiam
-    tag: v3.3
+    tag: v3.4
     pullPolicy: IfNotPresent
 
   ## agent whitelist of proxy routes matching this reg-ex
@@ -145,7 +145,7 @@ server:
 
   image:
     repository: quay.io/uswitch/kiam
-    tag: v3.3
+    tag: v3.4
     pullPolicy: IfNotPresent
 
   ## Logging settings


### PR DESCRIPTION
Currently the helm chart default to 3.3, it would be nice to default to the latest kiam release (3.4)