### PR TITLE
helm chart: update default gatewayTimeoutCreation

### DIFF
--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 4.1.0
+version: 4.2.0
 appVersion: 3.4
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -124,7 +124,7 @@ agent:
 
   ## Timeout when creating the kiam gateway
   ##
-  gatewayTimeoutCreation: 50ms
+  gatewayTimeoutCreation: 1s
 
   ## Base64-encoded PEM values for agent's CA certificate(s), certificate and private key
   ##
@@ -252,7 +252,7 @@ server:
 
   ## Timeout when creating the kiam gateway
   ##
-  gatewayTimeoutCreation: 50ms
+  gatewayTimeoutCreation: 1s
 
   ## Server probe configuration
   probes:


### PR DESCRIPTION
Bump default to 500ms, as 50ms leads to easy connection issues on busy nodes, especially when resource definitions are left empty so kiam is easily starved.

I would also propose to bump it here https://github.com/uswitch/kiam/blob/master/cmd/kiam/opts.go#L117

Related: #308