### PR TITLE
Helm: adding optional deep health check to the agent's liveness probe

### DIFF
--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Helm Chart Changelog
 
+## 5.1.0
+8 November 2019
+
+Notable changes:
+* [#319](https://github.com/uswitch/kiam/pull/319) Optional [deep liveness check](https://github.com/uswitch/kiam/pull/268) has been added to the helm chart.
+
+Many thanks to the following contributor for this release:
+* [@stanvit](https://github.com/stanvit)
+
 ## 5.0.0
 7 November 2019
 

--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 5.0.0
+version: 5.1.0
 appVersion: 3.4
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -113,6 +113,7 @@ Parameter | Description | Default
 `agent.host.port` | Agent's listening port | `8181`
 `agent.log.jsonOutput` | Whether or not to output agent log in JSON format | `true`
 `agent.log.level` | Agent log level (`debug`, `info`, `warn` or `error`) | `info`
+`agent.deepLivenessProbe` | Fail liveness probe if the server is not accessible | `false`
 `agent.nodeSelector` | Node labels for agent pod assignment | `{}`
 `agent.prometheus.port` | Agent Prometheus metrics port | `9620`
 `agent.prometheus.scrape` | Whether or not Prometheus metrics for the agent should be scraped | `true`

--- a/helm/kiam/templates/agent-daemonset.yaml
+++ b/helm/kiam/templates/agent-daemonset.yaml
@@ -129,7 +129,11 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
+              {{- if .Values.agent.deepLivenessProbe }}
+              path: /health?deep=1
+              {{- else }}
               path: /ping
+              {{- end }}
               port: {{ .Values.agent.host.port }}
             initialDelaySeconds: 3
             periodSeconds: 3

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -28,6 +28,13 @@ agent:
   log:
     jsonOutput: true
     level: info
+
+  ## if true, liveness probe will fail if the agent is not
+  ## able to communicate with servers, which may happen on
+  ## certificate change
+  ##
+  deepLivenessProbe: false
+
   ## Host networking settings
   ##
   host:


### PR DESCRIPTION
Implementing deep health check feature (#268) in the helm chart .

Agents are restarted when communication with masters fails, which may happen on certificate changes.