### PR TITLE
[helm] adds option to run server as deployment

### DIFF
--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 5.1.0
+version: 5.2.0
 appVersion: 3.4
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 5.2.0
+version: 5.3.0
 appVersion: 3.4
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/templates/server-deployment.yaml
+++ b/helm/kiam/templates/server-deployment.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.server.enabled ( eq .Values.server.deployment.enabled false) -}}
+{{- if and .Values.server.enabled .Values.server.deployment.enabled -}}
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   labels:
     app: {{ template "kiam.name" . }}
@@ -10,6 +10,7 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "kiam.fullname" . }}-server
 spec:
+  replicas: {{ .Values.server.deployment.replicas }}
   selector:
     matchLabels:
       app: {{ template "kiam.name" . }}
@@ -37,8 +38,21 @@ spec:
     {{- end }}
       tolerations:
 {{ toYaml .Values.server.tolerations | indent 8 }}
-      {{- if .Values.server.affinity }}
       affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - {{ template "kiam.name" . }}
+                  - key: "component"
+                    operator: In
+                    values:
+                      - {{ .Values.server.name }}
+              topologyKey: "kubernetes.io/hostname"
+      {{- if .Values.server.affinity }}
 {{ toYaml .Values.server.affinity | indent 10 }}
       {{- end }}
       volumes:

--- a/helm/kiam/templates/server-deployment.yaml
+++ b/helm/kiam/templates/server-deployment.yaml
@@ -11,6 +11,11 @@ metadata:
   name: {{ template "kiam.fullname" . }}-server
 spec:
   replicas: {{ .Values.server.deployment.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
   selector:
     matchLabels:
       app: {{ template "kiam.name" . }}

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -168,6 +168,12 @@ server:
     tag: v3.4
     pullPolicy: IfNotPresent
 
+  ## Run as Deployment instead of Daemonset
+  ##
+  deployment:
+    enabled: false
+    replicas: 3
+
   ## Logging settings
   ##
   log:


### PR DESCRIPTION
This relates to #296 and #245 

This provides the ability to run the server as a deployment in the helm chart.