### PR TITLE
Issue #217 - Add GRPC keepalive to server/client

### DIFF
--- a/pkg/server/gateway.go
+++ b/pkg/server/gateway.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 
 	status "google.golang.org/grpc/status"
 )

--- a/pkg/server/gateway.go
+++ b/pkg/server/gateway.go
@@ -53,7 +53,7 @@ const (
 	RetryInterval = 10 * time.Millisecond
 )
 
-var kacp = keepalive.ClientParameters{
+var keepAliveClientParams = keepalive.ClientParameters{
 	Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
 	Timeout:             time.Second,      // wait 1 second for ping ack before considering the connection dead
 	PermitWithoutStream: true,             // send pings even without active streams
@@ -92,7 +92,7 @@ func NewGateway(ctx context.Context, address string, caFile, certificateFile, ke
 	dialAddress := fmt.Sprintf("dns:///%s", address)
 
 	dialOpts := []grpc.DialOption{
-		grpc.WithKeepaliveParams(kacp),
+		grpc.WithKeepaliveParams(keepAliveClientParams),
 		grpc.WithTransportCredentials(creds),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(retry.UnaryClientInterceptor(callOpts...), grpc_prometheus.UnaryClientInterceptor)),
 		grpc.WithBalancerName(roundrobin.Name),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -41,6 +41,19 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
+var kaep = keepalive.EnforcementPolicy{
+	MinTime:             5 * time.Second, // If a client pings more than once every 5 seconds, terminate the connection
+	PermitWithoutStream: true,            // Allow pings even when there are no active streams
+}
+
+var kasp = keepalive.ServerParameters{
+	MaxConnectionIdle:     15 * time.Second, // If a client is idle for 15 seconds, send a GOAWAY
+	MaxConnectionAge:      30 * time.Second, // If any connection is alive for more than 30 seconds, send a GOAWAY
+	MaxConnectionAgeGrace: 5 * time.Second,  // Allow 5 seconds for pending RPCs to complete before forcibly closing connections
+	Time:                  5 * time.Second,  // Ping the client if it is idle for 5 seconds to ensure the connection is still active
+	Timeout:               1 * time.Second,  // Wait 1 second for the ping ack before assuming the connection is dead
+}
+
 // Config controls the setup of the gRPC server
 type Config struct {
 	BindAddress              string
@@ -275,6 +288,8 @@ func NewServer(config *Config) (*KiamServer, error) {
 	})
 
 	grpcServer := grpc.NewServer(
+		grpc.KeepaliveEnforcementPolicy(kaep), 
+		grpc.KeepaliveParams(kasp))
 		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -43,12 +43,12 @@ import (
 	
 )
 
-var kaep = keepalive.EnforcementPolicy{
+var keepAliveEnforcementPolicy = keepalive.EnforcementPolicy{
 	MinTime:             5 * time.Second, // If a client pings more than once every 5 seconds, terminate the connection
 	PermitWithoutStream: true,            // Allow pings even when there are no active streams
 }
 
-var kasp = keepalive.ServerParameters{
+var keepAliveServerParams = keepalive.ServerParameters{
 	MaxConnectionIdle:     15 * time.Second, // If a client is idle for 15 seconds, send a GOAWAY
 	MaxConnectionAge:      30 * time.Second, // If any connection is alive for more than 30 seconds, send a GOAWAY
 	MaxConnectionAgeGrace: 5 * time.Second,  // Allow 5 seconds for pending RPCs to complete before forcibly closing connections
@@ -290,8 +290,8 @@ func NewServer(config *Config) (*KiamServer, error) {
 	})
 
 	grpcServer := grpc.NewServer(
-		grpc.KeepaliveEnforcementPolicy(kaep), 
-		grpc.KeepaliveParams(kasp),
+		grpc.KeepaliveEnforcementPolicy(keepAliveEnforcementPolicy), 
+		grpc.KeepaliveParams(keepAliveServerParams),
 		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -33,12 +33,14 @@ import (
 	pb "github.com/uswitch/kiam/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	
 )
 
 var kaep = keepalive.EnforcementPolicy{
@@ -289,7 +291,7 @@ func NewServer(config *Config) (*KiamServer, error) {
 
 	grpcServer := grpc.NewServer(
 		grpc.KeepaliveEnforcementPolicy(kaep), 
-		grpc.KeepaliveParams(kasp))
+		grpc.KeepaliveParams(kasp),
 		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),


### PR DESCRIPTION
This PR adds a keepalive between servers/clients ensuring connections are closed correctly in the case of ungraceful KIAM server termination.

For reference:
Kiam issue - https://github.com/uswitch/kiam/issues/217
Go-GRPC issue: https://github.com/grpc/grpc-go/issues/3206

Putting this forward for review. I am currently running this patch in our main development cluster with no ill effects. I am not a golang dev by any stretch of the imagination so am not sure of the knock on effects of enabling this.