### PR TITLE
Helm service account annotations and fixes for deployments

### DIFF
--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Helm Chart Changelog
 
+## 5.4.0 (unreleased)
+
+Notable changes:
+* [#336](https://github.com/uswitch/kiam/pull/336) Add optional service-account annotations for server and agent.  Fix deployment to work with helm v3 and custom SSL host path.
+
 ## 5.3.0
 27 November 2019
 
@@ -13,7 +18,7 @@ Many thanks to the following contributor for this release:
 27 November 2019
 
 Notable changes:
-* [#320](https://github.com/uswitch/kiam/pull/320) The default SSL host path set for the Kiam server has been updated to match the default in the repo's deployment manifests. This path can now be configured from its own `values.yaml` option.  
+* [#320](https://github.com/uswitch/kiam/pull/320) The default SSL host path set for the Kiam server has been updated to match the default in the repo's deployment manifests. This path can now be configured from its own `values.yaml` option.
 Also, the Helm README has been updated to include documentation for key configuration elements.
 
 Many thanks to the following contributors for this release:
@@ -33,12 +38,12 @@ Many thanks to the following contributor for this release:
 7 November 2019
 
 **BREAKING CHANGES:**
-* [#322](https://github.com/uswitch/kiam/pull/322) The chart has been updated to include support for the `--no-iptables-remove` Kiam flag, which is now **enabled by default.**  
-`Note:` Using your existing `values.yaml` with this chart will result in the flag being turned on with no user input. This flag leaves the iptables rule (which is necessary for the Kiam agent processes to intercept requests to the metadata API) in place after the Kiam agent has been shutdown.  
+* [#322](https://github.com/uswitch/kiam/pull/322) The chart has been updated to include support for the `--no-iptables-remove` Kiam flag, which is now **enabled by default.**
+`Note:` Using your existing `values.yaml` with this chart will result in the flag being turned on with no user input. This flag leaves the iptables rule (which is necessary for the Kiam agent processes to intercept requests to the metadata API) in place after the Kiam agent has been shutdown.
 Please see the following links for related discussion: [Issue 202](https://github.com/uswitch/kiam/issues/202) and [PR #253](https://github.com/uswitch/kiam/pull/253).
 
 Many thanks to the following contributors for this release:
-* [@zytek](https://github.com/zytek)  
+* [@zytek](https://github.com/zytek)
 * [@Nuru](https://github.com/Nuru)
 
 ## 4.2.0
@@ -63,7 +68,7 @@ Many thanks to the following contributor for this release:
 16 October 2019
 
 **BREAKING CHANGES:**
-* [#307](https://github.com/uswitch/kiam/pull/307) Upgraded Kubernetes Apps API version for the DaemonSets in order to support Kubernetes 1.16+.  
+* [#307](https://github.com/uswitch/kiam/pull/307) Upgraded Kubernetes Apps API version for the DaemonSets in order to support Kubernetes 1.16+.
 `Note:` This API change has the effect of dropping support for Kubernetes >1.9. This release WILL NOT work for Kubernetes clusters running versions earlier than 1.9.
 
 Many thanks to the following contributor for this release:
@@ -97,7 +102,7 @@ Notable Changes:
 5 September 2019
 
 **BREAKING CHANGES:**
-* [#292](https://github.com/uswitch/kiam/pull/292) The `extraEnv` parameters for both the agent and server in `values.yaml` have been changed to support an array of options. This adds support for creating env vars from configMaps or secretKeyRefs.  
+* [#292](https://github.com/uswitch/kiam/pull/292) The `extraEnv` parameters for both the agent and server in `values.yaml` have been changed to support an array of options. This adds support for creating env vars from configMaps or secretKeyRefs.
 `Note:` This will break any existing Helm deployments which utilise the `extraEnv` parameters in `values.yaml`. You will need to update your `values.yaml` file to match the format in the [template](/helm/kiam/values.yaml#L93)
 
 ## 2.5.3

--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 5.3.0
+version: 5.4.0
 appVersion: 3.4
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/templates/agent-serviceaccount.yaml
+++ b/helm/kiam/templates/agent-serviceaccount.yaml
@@ -9,6 +9,9 @@ metadata:
     component: "{{ .Values.agent.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.serviceAccounts.agent.annotations }}
+  annotations: {{ toYaml .Values.serviceAccounts.agent.annotations | nindent 4 }}
+  {{- end }}
   name: {{ template "kiam.serviceAccountName.agent" . }}
 {{- end }}
 {{- end }}

--- a/helm/kiam/templates/server-deployment.yaml
+++ b/helm/kiam/templates/server-deployment.yaml
@@ -68,6 +68,9 @@ spec:
             {{else}}
             secretName: {{ template "kiam.fullname" . }}-server
             {{- end }}
+        - name: ssl-certs
+          hostPath:
+            path: {{ .Values.server.sslCertHostPath }}
       {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:
@@ -120,6 +123,9 @@ spec:
           volumeMounts:
             - mountPath: /etc/kiam/tls
               name: tls
+            - mountPath: /etc/ssl/certs
+              name: ssl-certs
+              readOnly: true
           {{- range .Values.server.extraHostPathMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}

--- a/helm/kiam/templates/server-deployment.yaml
+++ b/helm/kiam/templates/server-deployment.yaml
@@ -163,6 +163,4 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets }}
       {{- end }}
-  updateStrategy:
-    type: {{ .Values.server.updateStrategy }}
 {{- end }}

--- a/helm/kiam/templates/server-serviceaccount.yaml
+++ b/helm/kiam/templates/server-serviceaccount.yaml
@@ -9,6 +9,9 @@ metadata:
     component: "{{ .Values.server.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.serviceAccounts.server.annotations }}
+  annotations: {{ toYaml .Values.serviceAccounts.server.annotations | nindent 4 }}
+  {{- end }}
   name: {{ template "kiam.serviceAccountName.server" . }}
 {{- end }}
 {{- end }}

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -322,6 +322,8 @@ serviceAccounts:
   agent:
     create: true
     name:
+    annotations: {}
   server:
     create: true
     name:
+    annotations: {}


### PR DESCRIPTION
* Annotations to allow agent/service service-account annotations
* Fixes for deployment object spec, removing erroneous updateStrategy
* Add (back?) the mount of the host's SSL certs for deployments

I'm using these to work with EKS IAM roles for services accounts... do they look ok?