### PR TITLE
Helm chart 5.5.0 - kiam to 3.5 and expose gRPC keepalive parameters

### DIFF
--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Helm Chart Changelog
 
+## 5.5.0
+09 January 2020
+
+Notable changes:
+* [#x](https://github.com/uswitch/kiam/pull/x) Update kiam release from 3.4 to 3.5.
+
 ## 5.4.0
 10 December 2019
 

--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 Notable changes:
 * [#x](https://github.com/uswitch/kiam/pull/x) Update kiam release from 3.4 to 3.5.
+* Optional gRPC keepalive [#337](https://github.com/uswitch/kiam/pull/337) configuration has been added to the chart for the agent under the `keepaliveParams:` field.
 
 ## 5.4.0
 10 December 2019

--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -4,7 +4,7 @@
 09 January 2020
 
 Notable changes:
-* [#x](https://github.com/uswitch/kiam/pull/x) Update kiam release from 3.4 to 3.5.
+* [#353](https://github.com/uswitch/kiam/pull/353) Update kiam release from 3.4 to 3.5.
 * Optional gRPC keepalive [#337](https://github.com/uswitch/kiam/pull/337) configuration has been added to the chart for the agent under the `keepaliveParams:` field.
 
 ## 5.4.0

--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kiam
-version: 5.4.0
-appVersion: 3.4
+version: 5.5.0
+appVersion: 3.5
 description: Integrate AWS IAM with Kubernetes
 keywords:
   - kiam

--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -134,9 +134,9 @@ Parameter | Description | Default
 `agent.extraEnv` | Additional agent container environment variables | `{}`
 `agent.extraHostPathMounts` | Additional agent container hostPath mounts | `[]`
 `agent.gatewayTimeoutCreation` | Agent's timeout when creating the kiam gateway | `1s`
-`agent.keepaliveParams.time` | gRPC keepalive time in ms, uses agent default | `null`
-`agent.keepaliveParams.timeout` | gRPC keepalive timeout in ms, uses agent default | `null`
-`agent.keepaliveParams.permitWithoutStream` | gRPC keepalive ping even with no RPC, uses agent default | `null`
+`agent.keepaliveParams.time` | gRPC keepalive time | `10s`
+`agent.keepaliveParams.timeout` | gRPC keepalive timeout | `2s`
+`agent.keepaliveParams.permitWithoutStream` | gRPC keepalive ping even with no RPC | `false`
 `agent.host.ip` | IP address of host | `$(HOST_IP)`
 `agent.host.iptables` | Add iptables rule | `false`
 `agent.host.interface` | Agent's host interface for proxying AWS metadata | `cali+`

--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -126,7 +126,7 @@ Parameter | Description | Default
 `agent.enabled` | If true, create agent | `true`
 `agent.name` | Agent container name | `agent`
 `agent.image.repository` | Agent image | `quay.io/uswitch/kiam`
-`agent.image.tag` | Agent image tag | `v3.4`
+`agent.image.tag` | Agent image tag | `v3.5`
 `agent.image.pullPolicy` | Agent image pull policy | `IfNotPresent`
 `agent.dnsPolicy` | Agent pod DNS policy | `ClusterFirstWithHostNet`
 `agent.whiteListRouteRegexp` | Agent pod whitelist metadata API path argument regex  | `{}`
@@ -166,7 +166,7 @@ Parameter | Description | Default
 `server.name` | Server container name | `server`
 `server.gatewayTimeoutCreation` | Server's timeout when creating the kiam gateway | `1s`
 `server.image.repository` | Server image | `quay.io/uswitch/kiam`
-`server.image.tag` | Server image tag | `v3.4`
+`server.image.tag` | Server image tag | `v3.5`
 `server.image.pullPolicy` | Server image pull policy | `Always`
 `server.assumeRoleArn` | IAM role for the server to assume before processing requests | `null`
 `server.cache.syncInterval` | Pod cache synchronization interval | `1m`

--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -134,6 +134,9 @@ Parameter | Description | Default
 `agent.extraEnv` | Additional agent container environment variables | `{}`
 `agent.extraHostPathMounts` | Additional agent container hostPath mounts | `[]`
 `agent.gatewayTimeoutCreation` | Agent's timeout when creating the kiam gateway | `1s`
+`agent.keepaliveParams.time` | gRPC keepalive time in ms, uses agent default | `null`
+`agent.keepaliveParams.timeout` | gRPC keepalive timeout in ms, uses agent default | `null`
+`agent.keepaliveParams.permitWithoutStream` | gRPC keepalive ping even with no RPC, uses agent default | `null`
 `agent.host.ip` | IP address of host | `$(HOST_IP)`
 `agent.host.iptables` | Add iptables rule | `false`
 `agent.host.interface` | Agent's host interface for proxying AWS metadata | `cali+`

--- a/helm/kiam/templates/agent-daemonset.yaml
+++ b/helm/kiam/templates/agent-daemonset.yaml
@@ -109,7 +109,7 @@ spec:
             - --grpc-keepalive-timeout-ms={{ .Values.agent.keepaliveParams.timeout }}
             {{- end }}
             {{- if .Values.agent.keepaliveParams.PermitWithoutStream }}
-            - --grpc-keepalive-permit-without-stream={{ .Values.agent.keepaliveParams.PermitWithoutStream }}
+            - --grpc-keepalive-permit-without-stream
             {{- end }}
           {{- range $key, $value := .Values.agent.extraArgs }}
             {{- if $value }}

--- a/helm/kiam/templates/agent-daemonset.yaml
+++ b/helm/kiam/templates/agent-daemonset.yaml
@@ -102,6 +102,15 @@ spec:
             - --whitelist-route-regexp={{ .Values.agent.whiteListRouteRegexp }}
             {{- end }}
             - --gateway-timeout-creation={{ .Values.agent.gatewayTimeoutCreation }}
+            {{- if .Values.agent.keepaliveParams.time }}
+            - --grpc-keepalive-time-ms={{ .Values.agent.keepaliveParams.time }}
+            {{- end }}
+            {{- if .Values.agent.keepaliveParams.timeout }}
+            - --grpc-keepalive-timeout-ms={{ .Values.agent.keepaliveParams.timeout }}
+            {{- end }}
+            {{- if .Values.agent.keepaliveParams.PermitWithoutStream }}
+            - --grpc-keepalive-permit-without-stream={{ .Values.agent.keepaliveParams.PermitWithoutStream }}
+            {{- end }}
           {{- range $key, $value := .Values.agent.extraArgs }}
             {{- if $value }}
             - --{{ $key }}={{ $value }}

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -137,7 +137,7 @@ agent:
   ##
   gatewayTimeoutCreation: 1s
 
-  ## gRPC keepalice variables
+  ## gRPC keepalive variables
   ##
   keepaliveParams:
     time:

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -15,7 +15,7 @@ agent:
 
   image:
     repository: quay.io/uswitch/kiam
-    tag: v3.4
+    tag: v3.5
     pullPolicy: IfNotPresent
 
   ## agent whitelist of proxy routes matching this reg-ex
@@ -165,7 +165,7 @@ server:
 
   image:
     repository: quay.io/uswitch/kiam
-    tag: v3.4
+    tag: v3.5
     pullPolicy: IfNotPresent
 
   ## Run as Deployment instead of Daemonset

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -137,6 +137,14 @@ agent:
   ##
   gatewayTimeoutCreation: 1s
 
+  ## gRPC keepalice variables
+  ##
+  keepaliveParams:
+    time:
+    timeout:
+    ## gRPC keepalive ping even with no RPC
+    # permitWithoutStream: true
+
   ## Base64-encoded PEM values for agent's CA certificate(s), certificate and private key
   ##
   tlsFiles:


### PR DESCRIPTION
This change updates the Helm chart to 5.5.0 with the following changes.
* Update kiam from 3.4 to 3.5
* Expose the gRPC keepalive parameters added to kiam 3.5 in #337 