### PR TITLE
Add support for external ID annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ metadata:
     iam.amazonaws.com/role: reportingdb-reader
 ```
 
+kiam also supports the use of an external id annotation added to the `Pod` which
+maybe used to avoid [confused deputy scenarios in cross-organisation role assumption](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html),
+for example:
+
+```yaml
+kind: Pod
+metadata:
+  name: foo
+  namespace: cross-org-iam-example
+  annotations:
+    iam.amazonaws.com/role: arn:aws:iam::12345678901:role/trusted-partner
+    iam.amazonaws.com/external-id: d272840b-2859-41aa-b022-f4527bfef672
+
 Further, all namespaces must also have an annotation with a regular expression expressing which roles are permitted to be assumed within that namespace. **Without the namespace annotation the pod will be unable to assume any roles.**
 
 ```yaml

--- a/pkg/aws/sts/arn_resolver.go
+++ b/pkg/aws/sts/arn_resolver.go
@@ -29,18 +29,24 @@ func DefaultResolver(prefix string) *Resolver {
 }
 
 // Resolve converts from a role string into the absolute role arn.
-func (r *Resolver) Resolve(role string) string {
-	if role == "" {
-		return ""
+func (r *Resolver) Resolve(role string) (string, string) {
+	components := strings.Split(role, "|")
+
+	externalID := ""
+
+	if len(components) > 1 {
+		externalID = components[1]
 	}
+
+	role = components[0]
 
 	if strings.HasPrefix(role, "/") {
 		role = strings.TrimPrefix(role, "/")
 	}
 
 	if strings.HasPrefix(role, "arn:") {
-		return role
+		return role, externalID
 	}
 
-	return fmt.Sprintf("%s%s", r.prefix, role)
+	return fmt.Sprintf("%s%s", r.prefix, role), externalID
 }

--- a/pkg/aws/sts/arn_resolver_test.go
+++ b/pkg/aws/sts/arn_resolver_test.go
@@ -19,53 +19,73 @@ import (
 
 func TestAddsPrefix(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	role := resolver.Resolve("myrole")
+	role, externalID := resolver.Resolve("myrole")
 
 	if role != "arn:aws:iam::account-id:role/myrole" {
 		t.Error("unexpected role, was:", role)
 	}
+
+	if externalID != "" {
+		t.Error("unexpected external ID, was:", externalID)
+	}
 }
 
 func TestReturnsEmpty(t *testing.T) {
-	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	role := resolver.Resolve("")
+	resolver := DefaultResolver("")
+	role, externalID := resolver.Resolve("")
 
 	if role != "" {
 		t.Error("unexpected role, was:", role)
+	}
+
+	if externalID != "" {
+		t.Error("unexpected external ID, was:", externalID)
 	}
 }
 
 func TestAddsPrefixWithRoleBeginningWithSlash(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	role := resolver.Resolve("/myrole")
+	role, externalID := resolver.Resolve("/myrole")
 
 	if role != "arn:aws:iam::account-id:role/myrole" {
 		t.Error("unexpected role, was:", role)
 	}
+	if externalID != "" {
+		t.Error("unexpected external ID, was:", externalID)
+	}
 }
 func TestAddsPrefixWithRoleBeginningWithPathWithoutSlash(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	role := resolver.Resolve("kiam/myrole")
+	role, externalID := resolver.Resolve("kiam/myrole")
 
 	if role != "arn:aws:iam::account-id:role/kiam/myrole" {
 		t.Error("unexpected role, was:", role)
 	}
+	if externalID != "" {
+		t.Error("unexpected external ID, was:", externalID)
+	}
 }
 func TestAddsPrefixWithRoleBeginningWithSlashPath(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	role := resolver.Resolve("/kiam/myrole")
+	role, externalID := resolver.Resolve("/kiam/myrole")
 
 	if role != "arn:aws:iam::account-id:role/kiam/myrole" {
 		t.Error("unexpected role, was:", role)
+	}
+	if externalID != "" {
+		t.Error("unexpected external ID, was:", externalID)
 	}
 }
 
 func TestUsesAbsoluteARN(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	role := resolver.Resolve("arn:aws:iam::some-other-account:role/another-role")
+	role, externalID := resolver.Resolve("arn:aws:iam::some-other-account:role/another-role")
 
 	if role != "arn:aws:iam::some-other-account:role/another-role" {
 		t.Error("unexpected role, was:", role)
+	}
+	if externalID != "" {
+		t.Error("unexpected external ID, was:", externalID)
 	}
 }
 

--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -26,7 +26,6 @@ import (
 
 type credentialsCache struct {
 	arnResolver     ARNResolver
-	baseARN         string
 	cache           *cache.Cache
 	expiring        chan *RoleCredentials
 	sessionName     string
@@ -37,6 +36,7 @@ type credentialsCache struct {
 
 type RoleCredentials struct {
 	Role        string
+	ExternalId  string
 	Credentials *Credentials
 }
 
@@ -122,8 +122,8 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, role string) 
 	cacheMiss.Inc()
 
 	issue := func() (interface{}, error) {
-		arn := c.arnResolver.Resolve(role)
-		credentials, err := c.gateway.Issue(ctx, arn, c.sessionName, c.sessionDuration)
+		arn, externalID := c.arnResolver.Resolve(role)
+		credentials, err := c.gateway.Issue(ctx, arn, c.sessionName, externalID, c.sessionDuration)
 		if err != nil {
 			errorIssuing.Inc()
 			logger.Errorf("error requesting credentials: %s", err.Error())

--- a/pkg/aws/sts/interfaces.go
+++ b/pkg/aws/sts/interfaces.go
@@ -28,5 +28,5 @@ type CredentialsCache interface {
 
 // ARNResolver encapsulates resolution of roles into ARNs.
 type ARNResolver interface {
-	Resolve(role string) string
+	Resolve(role string) (string, string)
 }

--- a/pkg/prefetch/manager_test.go
+++ b/pkg/prefetch/manager_test.go
@@ -43,13 +43,13 @@ func TestPrefetchRunningPods(t *testing.T) {
 	manager := NewManager(cache, announcer)
 	go manager.Run(ctx, 1)
 
-	announcer.Announce(testutil.NewPodWithRole("ns", "name", "ip", "Running", "role"))
+	announcer.Announce(testutil.NewPodWithRole("ns", "name", "ip", "Running", "role", ""))
 	role := <-requestedRoles
 	if role != "role" {
 		t.Error("should have requested role")
 	}
 
-	announcer.Announce(testutil.NewPodWithRole("ns", "name", "ip", "Failed", "failed_role"))
+	announcer.Announce(testutil.NewPodWithRole("ns", "name", "ip", "Failed", "failed_role", ""))
 	select {
 	case role = <-requestedRoles:
 		t.Error("didn't expect to request role, but was requested", role)

--- a/pkg/server/policy.go
+++ b/pkg/server/policy.go
@@ -112,8 +112,8 @@ func (p *RequestingAnnotatedRolePolicy) IsAllowedAssumeRole(ctx context.Context,
 		return nil, err
 	}
 
-	annotatedRole := p.resolver.Resolve(k8s.PodRole(pod))
-	role = p.resolver.Resolve(role)
+	annotatedRole, _ := p.resolver.Resolve(k8s.PodRole(pod))
+	role, _ = p.resolver.Resolve(role)
 
 	if annotatedRole != role {
 		return &forbidden{requested: role, annotated: annotatedRole}, nil

--- a/pkg/server/policy_test.go
+++ b/pkg/server/policy_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestRequestedRolePolicy(t *testing.T) {
-	p := testutil.NewPodWithRole("namespace", "name", "192.168.0.1", testutil.PhaseRunning, "myrole")
+	p := testutil.NewPodWithRole("namespace", "name", "192.168.0.1", testutil.PhaseRunning, "myrole", "")
 	f := kt.NewStubFinder(p)
 
 	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
@@ -61,7 +61,7 @@ func TestRequestedRolePolicy(t *testing.T) {
 
 func TestRequestedRolePolicyWithSlash(t *testing.T) {
 	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
-	p := testutil.NewPodWithRole("namespace", "name", "192.168.0.1", testutil.PhaseRunning, "/myrole")
+	p := testutil.NewPodWithRole("namespace", "name", "192.168.0.1", testutil.PhaseRunning, "/myrole", "")
 	f := kt.NewStubFinder(p)
 
 	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
@@ -123,7 +123,7 @@ func TestErrorWhenPodNotFound(t *testing.T) {
 func TestNamespacePolicy(t *testing.T) {
 	n := testutil.NewNamespace("red", "^red.*$|^.red.*$")
 	nf := kt.NewNamespaceFinder(n)
-	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
+	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role", "")
 	pf := kt.NewStubFinder(p)
 
 	policy := NewNamespacePermittedRoleNamePolicy(nf, pf)
@@ -160,7 +160,7 @@ func TestNamespacePolicy(t *testing.T) {
 func TestNamespacePolicyWithSlash(t *testing.T) {
 	n := testutil.NewNamespace("red", "^red.*$|^.red.*$")
 	nf := kt.NewNamespaceFinder(n)
-	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
+	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role", "")
 	pf := kt.NewStubFinder(p)
 
 	policy := NewNamespacePermittedRoleNamePolicy(nf, pf)
@@ -197,7 +197,7 @@ func TestNamespacePolicyWithSlash(t *testing.T) {
 func TestNotAllowedWithoutNamespaceAnnotation(t *testing.T) {
 	n := testutil.NewNamespace("red", "")
 	nf := kt.NewNamespaceFinder(n)
-	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
+	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role", "")
 	pf := kt.NewStubFinder(p)
 
 	policy := NewNamespacePermittedRoleNamePolicy(nf, pf)
@@ -218,7 +218,7 @@ func TestNotAllowedWithoutNamespaceAnnotation(t *testing.T) {
 func TestNotAllowedWithoutNamespaceAnnotationWithSlash(t *testing.T) {
 	n := testutil.NewNamespace("red", "")
 	nf := kt.NewNamespaceFinder(n)
-	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
+	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role", "")
 	pf := kt.NewStubFinder(p)
 
 	policy := NewNamespacePermittedRoleNamePolicy(nf, pf)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	log "github.com/sirupsen/logrus"
 	"github.com/uswitch/k8sc/official"
 	"github.com/uswitch/kiam/pkg/aws/sts"
@@ -33,7 +33,7 @@ import (
 	pb "github.com/uswitch/kiam/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -238,7 +238,9 @@ func NewServer(config *Config) (*KiamServer, error) {
 		return nil, err
 	}
 
-	stsGateway, err := sts.DefaultGateway(arnResolver.Resolve(config.AssumeRoleArn), config.Region)
+	roleARN, _ := arnResolver.Resolve(config.AssumeRoleArn)
+
+	stsGateway, err := sts.DefaultGateway(roleARN, config.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testutil/kubernetes.go
+++ b/pkg/testutil/kubernetes.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,8 +54,11 @@ func NewPod(namespace, name, ip, phase string) *v1.Pod {
 	}
 }
 
-func NewPodWithRole(namespace, name, ip, phase, role string) *v1.Pod {
+func NewPodWithRole(namespace, name, ip, phase, role string, externalID string) *v1.Pod {
 	pod := NewPod(namespace, name, ip, phase)
 	pod.ObjectMeta.Annotations = map[string]string{"iam.amazonaws.com/role": role}
+	if externalID != "" {
+		pod.ObjectMeta.Annotations["iam.amazonaws.com/external-id"] = externalID
+	}
 	return pod
 }


### PR DESCRIPTION
Fixes #236 
Rebased version of #255

Adds support for external ID annotation. Instructions in updated README.

Note that https://github.com/patrickmn/go-cache can only work off a single key, hence this PR uses a pipe concatenation of the role and external ID as the cache key.