### PR TITLE
Update kube api resources

### DIFF
--- a/deploy/agent.yaml
+++ b/deploy/agent.yaml
@@ -1,74 +1,105 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: kube-system
+  annotations:
+    deprecated.daemonset.template.generation: "0"
+  creationTimestamp: null
+  labels:
+    app: kiam
+    role: agent
   name: kiam-agent
+  namespace: kube-system
 spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: kiam
+      role: agent
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: "true"
         prometheus.io/port: "9620"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
       labels:
         app: kiam
         role: agent
     spec:
-      hostNetwork: true
+      containers:
+      - args:
+        - agent
+        - --iptables
+        - --host-interface=cali+
+        - --json-log
+        - --port=8181
+        - --cert=/etc/kiam/tls/agent.pem
+        - --key=/etc/kiam/tls/agent-key.pem
+        - --ca=/etc/kiam/tls/ca.pem
+        - --server-address=kiam-server:443
+        - --prometheus-listen-addr=0.0.0.0:9620
+        - --prometheus-sync-interval=5s
+        - --gateway-timeout-creation=1s
+        command:
+        - /kiam
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        image: quay.io/uswitch/kiam:master
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ping
+            port: 8181
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: kiam
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs
+        - mountPath: /etc/kiam/tls
+          name: tls
+        - mountPath: /var/run/xtables.lock
+          name: xtables
       dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       nodeSelector:
         kubernetes.io/role: node
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
       volumes:
-        - name: ssl-certs
-          hostPath:
-            # for AWS linux or RHEL distros
-            # path: /etc/pki/ca-trust/extracted/pem/
-            # debian or ubuntu distros
-            # path: /etc/ssl/certs
-            path: /usr/share/ca-certificates
-        - name: tls
-          secret:
-            secretName: kiam-agent-tls
-        - name: xtables
-          hostPath:
-            path: /run/xtables.lock
-            type: FileOrCreate
-      containers:
-        - name: kiam
-          securityContext:
-            capabilities:
-              add: ["NET_ADMIN"]
-          image: quay.io/uswitch/kiam:master # USE A TAGGED RELEASE IN PRODUCTION
-          imagePullPolicy: Always
-          command:
-            - /kiam
-          args:
-            - agent
-            - --iptables
-            - --host-interface=cali+
-            - --json-log
-            - --port=8181
-            - --cert=/etc/kiam/tls/agent.pem
-            - --key=/etc/kiam/tls/agent-key.pem
-            - --ca=/etc/kiam/tls/ca.pem
-            - --server-address=kiam-server:443
-            - --prometheus-listen-addr=0.0.0.0:9620
-            - --prometheus-sync-interval=5s
-            - --gateway-timeout-creation=1s
-          env:
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-          volumeMounts:
-            - mountPath: /etc/ssl/certs
-              name: ssl-certs
-            - mountPath: /etc/kiam/tls
-              name: tls
-            - mountPath: /var/run/xtables.lock
-              name: xtables
-          livenessProbe:
-            httpGet:
-              path: /ping
-              port: 8181
-            initialDelaySeconds: 3
-            periodSeconds: 3
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: ""
+        name: ssl-certs
+      - name: tls
+        secret:
+          defaultMode: 420
+          secretName: kiam-agent-tls
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables
+  updateStrategy:
+    type: OnDelete
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0

--- a/deploy/server.daemonset.yaml
+++ b/deploy/server.daemonset.yaml
@@ -1,86 +1,110 @@
----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: kube-system
+  annotations:
+    deprecated.daemonset.template.generation: "0"
+  creationTimestamp: null
+  labels:
+    app: kiam
+    role: server
   name: kiam-server
+  namespace: kube-system
 spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: kiam
+      role: server
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: "true"
         prometheus.io/port: "9620"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
       labels:
         app: kiam
         role: server
     spec:
-      serviceAccountName: kiam-server
-      nodeSelector:
-        kubernetes.io/role: master
-      # kops master nodes requires this tolerations
-      # tolerations:
-      # - key: "node-role.kubernetes.io/master"
-      #   effect: "NoSchedule"
-      #   operator: "Exists"        
-      volumes:
-        - name: ssl-certs
-          hostPath:
-            # for AWS linux or RHEL distros
-            # path: /etc/pki/ca-trust/extracted/pem/
-            # debian or ubuntu distros
-            # path: /etc/ssl/certs
-            path: /usr/share/ca-certificates
-        - name: tls
-          secret:
-            secretName: kiam-server-tls
       containers:
-        - name: kiam
-          image: quay.io/uswitch/kiam:master # USE A TAGGED RELEASE IN PRODUCTION
-          imagePullPolicy: Always
-          command:
+      - args:
+        - server
+        - --json-log
+        - --level=warn
+        - --bind=0.0.0.0:443
+        - --cert=/etc/kiam/tls/server.pem
+        - --key=/etc/kiam/tls/server-key.pem
+        - --ca=/etc/kiam/tls/ca.pem
+        - --role-base-arn-autodetect
+        - --sync=1m
+        - --prometheus-listen-addr=0.0.0.0:9620
+        - --prometheus-sync-interval=5s
+        command:
+        - /kiam
+        image: quay.io/uswitch/kiam:master
+        imagePullPolicy: Always
+        livenessProbe:
+          exec:
+            command:
             - /kiam
-          args:
-            - server
-            - --json-log
-            - --level=warn
-            - --bind=0.0.0.0:443
+            - health
             - --cert=/etc/kiam/tls/server.pem
             - --key=/etc/kiam/tls/server-key.pem
             - --ca=/etc/kiam/tls/ca.pem
-            - --role-base-arn-autodetect
-            - --sync=1m
-            - --prometheus-listen-addr=0.0.0.0:9620
-            - --prometheus-sync-interval=5s
-          volumeMounts:
-            - mountPath: /etc/ssl/certs
-              name: ssl-certs
-            - mountPath: /etc/kiam/tls
-              name: tls
-          livenessProbe:
-            exec:
-              command:
-              - /kiam
-              - health
-              - --cert=/etc/kiam/tls/server.pem
-              - --key=/etc/kiam/tls/server-key.pem
-              - --ca=/etc/kiam/tls/ca.pem
-              - --server-address=127.0.0.1:443
-              - --gateway-timeout-creation=1s
-              - --timeout=5s
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 10
-          readinessProbe:
-            exec:
-              command:
-              - /kiam
-              - health
-              - --cert=/etc/kiam/tls/server.pem
-              - --key=/etc/kiam/tls/server-key.pem
-              - --ca=/etc/kiam/tls/ca.pem
-              - --server-address=127.0.0.1:443
-              - --gateway-timeout-creation=1s
-              - --timeout=5s
-            initialDelaySeconds: 3
-            periodSeconds: 10
-            timeoutSeconds: 10
+            - --server-address=127.0.0.1:443
+            - --gateway-timeout-creation=1s
+            - --timeout=5s
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: kiam
+        readinessProbe:
+          exec:
+            command:
+            - /kiam
+            - health
+            - --cert=/etc/kiam/tls/server.pem
+            - --key=/etc/kiam/tls/server-key.pem
+            - --ca=/etc/kiam/tls/ca.pem
+            - --server-address=127.0.0.1:443
+            - --gateway-timeout-creation=1s
+            - --timeout=5s
+          failureThreshold: 3
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs
+        - mountPath: /etc/kiam/tls
+          name: tls
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/role: master
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: kiam-server
+      serviceAccountName: kiam-server
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: ""
+        name: ssl-certs
+      - name: tls
+        secret:
+          defaultMode: 420
+          secretName: kiam-server-tls
+  updateStrategy:
+    type: OnDelete
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0


### PR DESCRIPTION
Hello there,

In preparation for upgrading to Kubernetes v1.16, (note: we have recently upgraded to v1.13), we have made changes to some of your kubernetes manifests.

The v1.16 release will stop serving a number of deprecated API versions in favor of newer and more stable API versions. For us, this means DaemonSet, Deployment, StatefulSet, and ReplicaSet all need to be updated to be using apps/v1. 

Any manifests referencing deprecated APIs (extensions/v1beta1, apps/v1beta1, or apps/v1beta2) will need to be updated before we roll out Kubernetes v1.16 in order to continue to work.

To lessen the work, we have gone through all the repositories and updated the resource APIs for you. We have pushed any changes to the `machinegun-<randomstring>` branch so feel free to make any changes and/or updates to this branch.

Note: If you are making changes, specifically to Deployments, make sure that you leave the Selector field under the Spec section as this is now mandatory.

During the conversion process, resources may have been updated with defaults and/or changed API fields. The defaults that you see were already in use but are now explicitly set.

Cosmetic changes may have also occurred, for example API fields may have moved around and comments may have been removed. Feel free to move API fields back to their original positions and re-add comments.

We appreciate your assistance in ensuring a smooth transition to Kubernetes v1.16.

If you have any questions, message in #cloud-infrastructure.

Thanks,

Cloud Team