### PR TITLE
Add missing sslCertHostPath as allowedHostPath in Helm Chart server PSP

### DIFF
--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 5.6.0
+version: 5.6.1
 appVersion: 3.5
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/templates/server-psp.yaml
+++ b/helm/kiam/templates/server-psp.yaml
@@ -10,14 +10,14 @@ spec:
   allowPrivilegeEscalation: false
   volumes:
     - 'secret'
-{{- if .Values.server.extraHostPathMounts }}
     - 'hostPath'
-  {{- range .Values.server.extraHostPathMounts }}
   allowedHostPaths:
+  - pathPrefix: {{ .Values.server.sslCertHostPath }}
+    readOnly: true
+  {{- range .Values.server.extraHostPathMounts }}
   - pathPrefix: {{ .hostPath }}
     readOnly: {{ .readOnly }}
   {{- end }}
-{{- end }}
   hostNetwork: {{ .Values.server.useHostNetwork }}
   hostIPC: false
   hostPID: false


### PR DESCRIPTION
When using PSPs, the current helm chart does not automatically add the `sslCertHostPath` as an `allowedHostPath`, which causes the server to be unable to start.

This also fixes the (I think) misplaced `range` in the PSP.