### PR TITLE
Remove unnecessary note about older cert-manager versions

### DIFF
--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -124,6 +124,3 @@ spec:
   ipAddresses:
   - "127.0.0.1"
 ```
-
-In order to use the `ipAddresses` option at the end you need at least `v0.7.0` of cert-manager.
-If you use an older version of cert manager, you can use `--server-address=localhost:443` to use the name `localhost` instead.


### PR DESCRIPTION
Line 64 and the whole example configuration already imposes a requirement of at least v0.11.0 since https://github.com/uswitch/kiam/pull/355, so the removed line is no longer relevant