### PR TITLE
Refactor unnecessary usage of channels

### DIFF
--- a/pkg/aws/metadata/handler_health.go
+++ b/pkg/aws/metadata/handler_health.go
@@ -73,15 +73,11 @@ func (h *healthHandler) Handle(ctx context.Context, w http.ResponseWriter, req *
 }
 
 func findServerHealth(ctx context.Context, client server.Client) (string, error) {
-
-	healthCh := make(chan string, 1)
+	var health string
 	op := func() error {
-		health, err := client.Health(ctx)
-		if err != nil {
-			return err
-		}
-		healthCh <- health
-		return nil
+		var err error
+		health, err = client.Health(ctx)
+		return err
 	}
 
 	strategy := backoff.NewExponentialBackOff()
@@ -92,7 +88,7 @@ func findServerHealth(ctx context.Context, client server.Client) (string, error)
 		return "", err
 	}
 
-	return <-healthCh, nil
+	return health, nil
 }
 
 func newHealthHandler(client server.Client, endpoint string) *healthHandler {

--- a/pkg/aws/metadata/handler_role_name.go
+++ b/pkg/aws/metadata/handler_role_name.go
@@ -92,14 +92,14 @@ const (
 func findRole(ctx context.Context, client server.Client, ip string) (string, error) {
 	logger := log.WithField("pod.ip", ip)
 
-	roleCh := make(chan string, 1)
+	var role string
 	op := func() error {
-		role, err := client.GetRole(ctx, ip)
+		var err error
+		role, err = client.GetRole(ctx, ip)
 		if err != nil {
 			logger.Warnf("error finding role for pod: %s", err.Error())
 			return err
 		}
-		roleCh <- role
 		return nil
 	}
 
@@ -111,7 +111,7 @@ func findRole(ctx context.Context, client server.Client, ip string) (string, err
 		return "", err
 	}
 
-	return <-roleCh, nil
+	return role, nil
 }
 
 func newRoleHandler(client server.Client, getClientIP clientIPFunc) *roleHandler {


### PR DESCRIPTION
Some handlers create a new local channel, send to it in the `backoff.Retry` handler, and receive from it after the `backoff.Retry` call returns with a non-nil error. This is all sequential code that needs no synchronization (and its overhead), and can be expressed without using any synchronization mechanism like channels.

This changelist removes the usage of channels where it's not required and refactors it to use local assignment.