### PR TITLE
Support IMDS v2

### DIFF
--- a/pkg/aws/metadata/handler_proxy.go
+++ b/pkg/aws/metadata/handler_proxy.go
@@ -27,6 +27,8 @@ type proxyHandler struct {
 	whitelistRouteRegexp *regexp.Regexp
 }
 
+var tokenRouteRegexp = regexp.MustCompile("^/?[^/]+/api/token$")
+
 func (p *proxyHandler) Install(router *mux.Router) {
 	router.PathPrefix("/").Handler(adapt(withMeter("proxy", p)))
 }
@@ -42,7 +44,9 @@ func (w *teeWriter) WriteHeader(statusCode int) {
 }
 
 func (p *proxyHandler) Handle(ctx context.Context, w http.ResponseWriter, r *http.Request) (int, error) {
-	if p.whitelistRouteRegexp.MatchString(r.URL.Path) {
+	if p.whitelistRouteRegexp.MatchString(r.URL.Path) ||
+		// Always proxy through requests to pick up a session token
+		(r.Method == http.MethodPut && tokenRouteRegexp.MatchString(r.URL.Path)) {
 		writer := &teeWriter{w, http.StatusOK}
 		// Passing the request through with no RemoteAddr prevents the backing service adding an X-Forwarded-For header.
 		// This is important, because v2 of the EC2 Instance Metadata API blocks all requests containing such a header

--- a/pkg/aws/metadata/handler_proxy.go
+++ b/pkg/aws/metadata/handler_proxy.go
@@ -44,6 +44,9 @@ func (w *teeWriter) WriteHeader(statusCode int) {
 func (p *proxyHandler) Handle(ctx context.Context, w http.ResponseWriter, r *http.Request) (int, error) {
 	if p.whitelistRouteRegexp.MatchString(r.URL.Path) {
 		writer := &teeWriter{w, http.StatusOK}
+		// Passing the request through with no RemoteAddr prevents the backing service adding an X-Forwarded-For header.
+		// This is important, because v2 of the EC2 Instance Metadata API blocks all requests containing such a header
+		r.RemoteAddr = ""
 		p.backingService.ServeHTTP(writer, r)
 
 		if writer.status == http.StatusOK {


### PR DESCRIPTION
fixes #359 

- Prevent the reverse proxy adding an X-Forwarded-For header
- Allow PUT requests to `*/api/token` without consulting the API whitelist
- Authenticate handing out roles by checking the session against the metadata API