### PR TITLE
Return credentials with trailing slash

### DIFF
--- a/pkg/aws/metadata/handler_credentials.go
+++ b/pkg/aws/metadata/handler_credentials.go
@@ -17,13 +17,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/cenkalti/backoff"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uswitch/kiam/pkg/aws/sts"
 	"github.com/uswitch/kiam/pkg/server"
 	"github.com/uswitch/kiam/pkg/statsd"
-	"net/http"
 )
 
 type credentialsHandler struct {
@@ -32,7 +33,9 @@ type credentialsHandler struct {
 }
 
 func (c *credentialsHandler) Install(router *mux.Router) {
-	router.Handle("/{version}/meta-data/iam/security-credentials/{role:.*}", adapt(withMeter("credentials", c)))
+	handler := adapt(withMeter("credentials", c))
+	router.Handle("/{version}/meta-data/iam/security-credentials/{role:.*}/", handler)
+	router.Handle("/{version}/meta-data/iam/security-credentials/{role:.*}", handler)
 }
 
 func (c *credentialsHandler) Handle(ctx context.Context, w http.ResponseWriter, req *http.Request) (int, error) {


### PR DESCRIPTION
Fixes #383.

Adds a second handler with a trailing slash. I initially tried doing this with a single handler but it broke all the tests.

Opted not to use the redirect method used elsewhere because, in this case, the version without the trailing slash is canonical but clients affected by this issue aren't guaranteed to follow redirects and the real metadata service returns a 200 for both.