### PR TITLE
Use Alpine Linux 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY Makefile Makefile
 
 RUN make bin/kiam-linux-amd64
 
-FROM alpine:3.8
+FROM alpine:3.11
 RUN apk --no-cache add iptables
 COPY --from=build /workspace/bin/kiam-linux-amd64 /kiam
 CMD []


### PR DESCRIPTION
Fixes #386

Bumping the version of Alpine Linux used for Kiam to latest release in order to address the arch-specific CVE for musl libc shipped with Alpine Linux.

CVE details:
https://www.cvedetails.com/cve/CVE-2019-14697/
https://www.openwall.com/lists/oss-security/2019/08/06/4