### PR TITLE
update example daemonsets to apps/v1 api

### DIFF
--- a/deploy/agent.yaml
+++ b/deploy/agent.yaml
@@ -1,9 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: kube-system
   name: kiam-agent
 spec:
+  selector:
+    matchLabels:
+      app: kiam
+      role: agent
+  updateStrategy:
+    type: OnDelete
   template:
     metadata:
       annotations:

--- a/deploy/server.daemonset.yaml
+++ b/deploy/server.daemonset.yaml
@@ -1,10 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: kube-system
   name: kiam-server
 spec:
+  selector:
+    matchLabels:
+      app: kiam
+      role: server
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -21,7 +27,7 @@ spec:
       # tolerations:
       # - key: "node-role.kubernetes.io/master"
       #   effect: "NoSchedule"
-      #   operator: "Exists"        
+      #   operator: "Exists"
       volumes:
         - name: ssl-certs
           hostPath:


### PR DESCRIPTION
The extensions/v1beta1 api has been removed in kube 1.16, this PR updates our examples to use the apps/v1 api which has been available since kube 1.9.