### PR TITLE
Check session token before handing out roles with the metadata API

### DIFF
--- a/pkg/aws/metadata/handler_authentication.go
+++ b/pkg/aws/metadata/handler_authentication.go
@@ -1,0 +1,46 @@
+package metadata
+
+import (
+	"bytes"
+ 	"context"
+	"net/http"
+	"net/url"
+)
+
+type authenticatingHandler struct {
+	downstreamHandler handler
+	client            http.Client
+	endpoint          url.URL
+}
+
+func NewAuthenticatingHandler(downstreamHandler handler, metadataEndpoint url.URL) authenticatingHandler {
+	return authenticatingHandler{
+		downstreamHandler: downstreamHandler,
+		endpoint: metadataEndpoint,
+	}
+}
+
+func (h authenticatingHandler) Handle(ctx context.Context, w http.ResponseWriter, req *http.Request) (int, error) {
+	authURL := h.endpoint
+	authURL.Path = req.URL.Path
+
+	authContext := context.Background()
+
+	authRequest  := req.Clone(authContext)
+	authRequest.URL = &authURL
+
+	authResponse, err := h.client.Do(authRequest)
+
+	if err == nil && authResponse.StatusCode == http.StatusOK {
+		return h.downstreamHandler.Handle(ctx, w, req)
+	} else if err != nil {
+		return http.StatusBadGateway, err
+	} else {
+		buffer := bytes.NewBuffer(make([]byte, 0, authResponse.ContentLength))
+		_, err = buffer.ReadFrom(authResponse.Body)
+
+		w.WriteHeader(authResponse.StatusCode)
+		w.Write(buffer.Bytes())
+		return authResponse.StatusCode, nil
+	}
+}

--- a/pkg/aws/metadata/handler_authentication_test.go
+++ b/pkg/aws/metadata/handler_authentication_test.go
@@ -1,0 +1,148 @@
+package metadata
+
+import (
+ 	"context"
+	"github.com/fortytw2/leaktest"
+	"github.com/gorilla/mux"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+type testHandler struct {
+	Status int
+	Err error
+}
+
+func (h testHandler) Handle(_ context.Context, res http.ResponseWriter, _ *http.Request) (int, error) {
+	res.Write([]byte("handling"))
+	return h.Status, h.Err
+}
+
+func installAsTestHandler(h handler, router *mux.Router) {
+	handler := adapt(withMeter("test", h))
+	router.Handle("/test", handler)
+}
+
+func TestGoodAuth(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusOK)
+		res.Write([]byte("unused"))
+	}))
+	defer func() { testServer.Close() }()
+
+	r, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Error("Error creating http request")
+	}
+	rr := httptest.NewRecorder()
+	rootHandler := testHandler{Status: http.StatusOK, Err: nil}
+
+	authUrl, err  := url.Parse(testServer.URL)
+	if err != nil {
+		t.Error("Error getting server URL")
+	}
+
+	handler := NewAuthenticatingHandler(rootHandler, *authUrl)
+
+	router := mux.NewRouter()
+	installAsTestHandler(handler, router)
+
+	router.ServeHTTP(rr, r)
+	if rr.Code != http.StatusOK {
+		t.Error("Expected 200 response, was", rr.Code)
+	}
+
+	body, err := ioutil.ReadAll(rr.Body)
+	if err != nil {
+		t.Error("Error reading body of metadata response")
+	}
+
+	if string(body) != "handling" {
+		t.Errorf("Did not receive expected response body. Got: %s", string(body))
+	}
+}
+
+func TestBadAuth(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusForbidden)
+		res.Write([]byte("nope"))
+	}))
+	defer func() { testServer.Close() }()
+
+	r, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Error("Error creating http request")
+	}
+	rr := httptest.NewRecorder()
+	rootHandler := testHandler{Status: http.StatusOK, Err: nil}
+
+	authUrl, err  := url.Parse(testServer.URL)
+	if err != nil {
+		t.Error("Error getting server URL")
+	}
+
+	handler := NewAuthenticatingHandler(rootHandler, *authUrl)
+
+	router := mux.NewRouter()
+	installAsTestHandler(handler, router)
+
+	router.ServeHTTP(rr, r)
+	if rr.Code != http.StatusForbidden {
+		t.Error("Expected 403 response, was", rr.Code)
+	}
+
+	body, err := ioutil.ReadAll(rr.Body)
+	if err != nil {
+		t.Error("Error reading body of metadata response")
+	}
+
+	if string(body) != "nope" {
+		t.Errorf("Did not receive expected response body. Got: %s", string(body))
+	}
+}
+
+func TestHeadersArePassedThrough(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if(len(req.Header["X-Aws-Ec2-Metadata-Token"]) > 0) {
+			res.WriteHeader(http.StatusOK)
+			res.Write([]byte("yup"))
+		} else {
+			res.WriteHeader(http.StatusForbidden)
+			res.Write([]byte("nope"))
+		}
+	}))
+	defer func() { testServer.Close() }()
+
+	r, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		t.Error("Error creating http request")
+	}
+
+	r.Header.Add("X-aws-ec2-metadata-token", "a token")
+	rr := httptest.NewRecorder()
+	rootHandler := testHandler{Status: http.StatusOK, Err: nil}
+
+	authUrl, err  := url.Parse(testServer.URL)
+	if err != nil {
+		t.Error("Error getting server URL")
+	}
+
+	handler := NewAuthenticatingHandler(rootHandler, *authUrl)
+
+	router := mux.NewRouter()
+	installAsTestHandler(handler, router)
+
+	router.ServeHTTP(rr, r)
+	if rr.Code != http.StatusOK {
+		t.Error("Expected the X-Aws-Ec2-Metadata-Token header to be passed through, but got a non-200 response indicating that this is not the case. Response code: ", rr.Code)
+	}
+}

--- a/pkg/aws/metadata/handler_credentials.go
+++ b/pkg/aws/metadata/handler_credentials.go
@@ -31,8 +31,8 @@ type credentialsHandler struct {
 	getClientIP clientIPFunc
 }
 
-func (c *credentialsHandler) Install(router *mux.Router) {
-	router.Handle("/{version}/meta-data/iam/security-credentials/{role:.*}", adapt(withMeter("credentials", c)))
+func InstallAsCredentialsHandler(h handler, router *mux.Router) {
+	router.Handle("/{version}/meta-data/iam/security-credentials/{role:.*}", adapt(withMeter("credentials", h)))
 }
 
 func (c *credentialsHandler) Handle(ctx context.Context, w http.ResponseWriter, req *http.Request) (int, error) {

--- a/pkg/aws/metadata/handler_credentials_test.go
+++ b/pkg/aws/metadata/handler_credentials_test.go
@@ -31,7 +31,7 @@ func TestReturnsCredentials(t *testing.T) {
 	client := st.NewStubClient().WithRoles(st.GetRoleResult{"role", nil}).WithCredentials(st.GetCredentialsResult{&sts.Credentials{AccessKeyId: "A1", SecretAccessKey: "S1"}, nil})
 	handler := newCredentialsHandler(client, getBlankClientIP)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsCredentialsHandler(handler, router)
 
 	router.ServeHTTP(rr, r.WithContext(ctx))
 
@@ -70,7 +70,7 @@ func TestReturnsErrorWithNoPod(t *testing.T) {
 	client := st.NewStubClient().WithCredentials(st.GetCredentialsResult{nil, server.ErrPodNotFound})
 	handler := newCredentialsHandler(client, getBlankClientIP)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsCredentialsHandler(handler, router)
 
 	router.ServeHTTP(rr, r.WithContext(ctx))
 
@@ -95,7 +95,7 @@ func TestReturnsCredentialsWithRetryAfterError(t *testing.T) {
 	client := st.NewStubClient().WithRoles(st.GetRoleResult{"role", nil}).WithCredentials(e, valid)
 	handler := newCredentialsHandler(client, getBlankClientIP)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsCredentialsHandler(handler, router)
 
 	router.ServeHTTP(rr, r.WithContext(ctx))
 
@@ -117,7 +117,7 @@ func TestForbiddenRole(t *testing.T) {
 	client := st.NewStubClient().WithRoles(st.GetRoleResult{"role", nil}).WithCredentials(e, valid)
 	handler := newCredentialsHandler(client, getBlankClientIP)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsCredentialsHandler(handler, router)
 
 	router.ServeHTTP(rr, r.WithContext(ctx))
 

--- a/pkg/aws/metadata/handler_health.go
+++ b/pkg/aws/metadata/handler_health.go
@@ -30,7 +30,7 @@ type healthHandler struct {
 	endpoint string
 }
 
-func (h *healthHandler) Install(router *mux.Router) {
+func InstallAsHealthHandler(h handler, router *mux.Router) {
 	router.Handle("/health", adapt(withMeter("health", h)))
 }
 

--- a/pkg/aws/metadata/handler_health_test.go
+++ b/pkg/aws/metadata/handler_health_test.go
@@ -25,7 +25,7 @@ func TestHealthReturn(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := newHealthHandler(st.NewStubClient(), testServer.URL)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsHealthHandler(handler, router)
 	router.ServeHTTP(rr, r)
 	if rr.Code != http.StatusOK {
 		t.Error("expected 200 response, was", rr.Code)
@@ -54,7 +54,7 @@ func TestDeepHealthBadReturn(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := newHealthHandler(st.NewStubClient().WithHealth("bad"), testServer.URL)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsHealthHandler(handler, router)
 	router.ServeHTTP(rr, r)
 	if rr.Code != http.StatusInternalServerError {
 		t.Error("expected 500 response, was", rr.Code)
@@ -76,7 +76,7 @@ func TestDeepHealthReturn(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := newHealthHandler(st.NewStubClient().WithHealth("ok"), testServer.URL)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsHealthHandler(handler, router)
 	router.ServeHTTP(rr, r)
 	if rr.Code != http.StatusOK {
 		t.Error("expected 200 response, was", rr.Code)

--- a/pkg/aws/metadata/handler_proxy.go
+++ b/pkg/aws/metadata/handler_proxy.go
@@ -29,8 +29,8 @@ type proxyHandler struct {
 
 var tokenRouteRegexp = regexp.MustCompile("^/?[^/]+/api/token$")
 
-func (p *proxyHandler) Install(router *mux.Router) {
-	router.PathPrefix("/").Handler(adapt(withMeter("proxy", p)))
+func InstallAsProxyHandler(h handler, router *mux.Router) {
+	router.PathPrefix("/").Handler(adapt(withMeter("proxy", h)))
 }
 
 type teeWriter struct {

--- a/pkg/aws/metadata/handler_proxy_test.go
+++ b/pkg/aws/metadata/handler_proxy_test.go
@@ -38,7 +38,7 @@ func performRequest(allowed, path string, method string, returnCode int) (int, *
 	})
 	handler := newProxyHandler(backingService, regexp.MustCompile(allowed))
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsProxyHandler(handler, router)
 
 	r, _ := http.NewRequest(method, path, nil)
 	rr := httptest.NewRecorder()

--- a/pkg/aws/metadata/handler_role_name.go
+++ b/pkg/aws/metadata/handler_role_name.go
@@ -44,7 +44,7 @@ func trailingSlashSuffixRedirectHandler(rw http.ResponseWriter, req *http.Reques
 	http.Redirect(rw, req, u.String(), http.StatusMovedPermanently)
 }
 
-func (h *roleHandler) Install(router *mux.Router) {
+func InstallAsRoleNameHandler(h handler, router *mux.Router) {
 	handler := adapt(withMeter("roleName", h))
 	router.Handle("/{version}/meta-data/iam/security-credentials/", handler)
 	router.HandleFunc("/{version}/meta-data/iam/security-credentials", trailingSlashSuffixRedirectHandler)

--- a/pkg/aws/metadata/handler_role_name_test.go
+++ b/pkg/aws/metadata/handler_role_name_test.go
@@ -22,7 +22,7 @@ func TestRedirectsToCanonicalPath(t *testing.T) {
 
 	handler := newRoleHandler(nil, nil)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsRoleNameHandler(handler, router)
 
 	router.ServeHTTP(rr, r)
 
@@ -58,7 +58,7 @@ func TestIncrementsPrometheusCounter(t *testing.T) {
 
 	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"foo_role", nil}), getBlankClientIP)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsRoleNameHandler(handler, router)
 
 	router.ServeHTTP(rr, r)
 
@@ -79,7 +79,7 @@ func TestReturnRoleWhenClientResponds(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"foo_role", nil}), getBlankClientIP)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsRoleNameHandler(handler, router)
 
 	router.ServeHTTP(rr, r)
 
@@ -100,7 +100,7 @@ func TestReturnRoleWhenRetryingFollowingError(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", fmt.Errorf("unexpected error")}, st.GetRoleResult{"foo_role", nil}), getBlankClientIP)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsRoleNameHandler(handler, router)
 
 	router.ServeHTTP(rr, r)
 
@@ -121,7 +121,7 @@ func TestReturnsEmptyRoleWhenClientSucceedsWithEmptyRole(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", nil}), getBlankClientIP)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsRoleNameHandler(handler, router)
 
 	router.ServeHTTP(rr, r)
 
@@ -140,7 +140,7 @@ func TestReturnErrorWhenPodNotFoundWithinTimeout(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler := newRoleHandler(st.NewStubClient().WithRoles(st.GetRoleResult{"", server.ErrPodNotFound}), getBlankClientIP)
 	router := mux.NewRouter()
-	handler.Install(router)
+	InstallAsRoleNameHandler(handler, router)
 
 	router.ServeHTTP(rr, r.WithContext(ctx))
 


### PR DESCRIPTION
For each request except those we proxy through to the metadata API, make a request to that API in order to ensure the session token is valid.

This is the second part of supporting IMDSv2. It mimics the behaviour of the metadata service itself when handing out roles:

 - If a session token is included in the request, it's checked (in this case, by hitting the IMDS)
 - If _no_ session token is included in the request, we still hit the IMDS to ensure that IMDSv1 is still enabled on the host - if it is, that request will succeed and we'll still return credentials.

I don't think this is strictly _required_ for IMDSv2 to function, it's just the best way I could think of to follow the _spirit_ of the changes. No problem at all if you'd rather do this another way, or not at all.