### PR TITLE
Continue startup if the statsd endpoint can't be set up

### DIFF
--- a/cmd/kiam/opts.go
+++ b/cmd/kiam/opts.go
@@ -79,7 +79,9 @@ func (o telemetryOptions) start(ctx context.Context, identifier string) {
 	)
 
 	if err != nil {
-		log.Fatalf("Error initing statsd: %v", err)
+		log.Errorf("Error initing statsd: %v", err)
+		log.Error("Continuing startup with statsd disabled...")
+		statsd.New("", "", o.statsDInterval)
 	}
 
 	if o.prometheusListen != "" {


### PR DESCRIPTION
We noticed that on startup Kiam, if for whatever reason it can't resolve its statsd endpoint, exits with a fatal error. Since it's _possible_ for Kiam to run without a statsd endpoint, how would you feel about continuïng startup in this case? 

No real pressure (I can understand why you might like to have it work either way), and also totally cool if this implementation isn't up to scratch for whatever reason, but I made a pull request because it seemed like a pretty small change.

Thank you! 