### PR TITLE
add retries around iptable rule removal

### DIFF
--- a/cmd/kiam/iptables.go
+++ b/cmd/kiam/iptables.go
@@ -79,7 +79,7 @@ func (r *rules) Remove() error {
 			break
 		}
 		if err := ipt.Delete("nat", "PREROUTING", r.ruleSpec()...); err == nil {
-			log.Info("iptables rule was removed", err.Error())
+			log.Info("iptables rule was successfully removed")
 			break
 		}
 		log.Warnf("failed to remove iptables rule, will retry: %s", err.Error())

--- a/cmd/kiam/iptables.go
+++ b/cmd/kiam/iptables.go
@@ -62,8 +62,8 @@ func (r *rules) ruleSpec() []string {
 }
 
 var (
-	retryInterval = time.Second * 1
-	maxAttempts   = 15
+	retryInterval = time.Millisecond * 500
+	maxAttempts   = 30
 )
 
 func (r *rules) Remove() error {
@@ -83,7 +83,7 @@ func (r *rules) Remove() error {
 			break
 		}
 		log.Warnf("failed to remove iptables rule, will retry: %s", err.Error())
-		time.Sleep(time.Second * 1)
+		time.Sleep(retryInterval)
 		attempt++
 	}
 	return nil


### PR DESCRIPTION
Fixes #396 

This adds basic retries around removing the IPTable rule for kiam-agent when the pod is terminated.

Given the process is exiting anyway, we cannot really 'guarantee' removal, but these retries will make it highly unlikely that a rule is left behind.

The call to `Remove()` gets deferred regardless of error anyway, so we might as well retry internally.

https://github.com/uswitch/kiam/blob/6e07571932910d71a8d99a7b4dd0325e09baf9b4/cmd/kiam/agent.go#L68-L70