### PR TITLE
fix server affinity

### DIFF
--- a/helm/kiam/templates/server-deployment.yaml
+++ b/helm/kiam/templates/server-deployment.yaml
@@ -58,7 +58,7 @@ spec:
                       - {{ .Values.server.name }}
               topologyKey: "kubernetes.io/hostname"
       {{- if .Values.server.affinity }}
-{{ toYaml .Values.server.affinity | indent 10 }}
+{{ toYaml .Values.server.affinity | indent 8 }}
       {{- end }}
       volumes:
         - name: tls


### PR DESCRIPTION
Hi, 

Currently, there is an issue with the server deployment and affinity. When an affinity is set we get the following error:

> Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.affinity.podAntiAffinity): unknown field "nodeAffinity" in io.k8s.api.core.v1.PodAntiAffinity

This is due to wrong indentation on the affinity spec. This PR fixes this issue.
Let me know if you need anything else.