### PR TITLE
Fix indentation on seLinuxOptions in server daemonset in Helm chart

### DIFF
--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 5.8.0
+version: 5.8.1
 appVersion: 3.5
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/templates/server-daemonset.yaml
+++ b/helm/kiam/templates/server-daemonset.yaml
@@ -108,7 +108,7 @@ spec:
           {{- if .Values.server.seLinuxOptions }}
           securityContext:
             seLinuxOptions:
-          {{ toYaml .Values.server.seLinuxOptions | indent 14 }}
+{{ toYaml .Values.server.seLinuxOptions | indent 14 }}
           {{- end }}
           volumeMounts:
             - mountPath: /etc/kiam/tls


### PR DESCRIPTION
Fixes Helm indentation error from #404 that causes YAML parse errors if using a server daemonset with seLinuxOptions.