### PR TITLE
Allow not mounting SSL certs from host

### DIFF
--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 5.9.0
+version: 5.10.0
 appVersion: 3.6
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/templates/server-daemonset.yaml
+++ b/helm/kiam/templates/server-daemonset.yaml
@@ -49,9 +49,11 @@ spec:
             {{else}}
             secretName: {{ template "kiam.fullname" . }}-server
             {{- end }}
+        {{- if .Values.server.sslCertHostPath }}
         - name: ssl-certs
           hostPath:
             path: {{ .Values.server.sslCertHostPath }}
+        {{- end }}
       {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:
@@ -113,9 +115,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/kiam/tls
               name: tls
+            {{- if .Values.server.sslCertHostPath }}
             - mountPath: /etc/ssl/certs
               name: ssl-certs
               readOnly: true
+            {{- end }}
           {{- range .Values.server.extraHostPathMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}

--- a/helm/kiam/templates/server-deployment.yaml
+++ b/helm/kiam/templates/server-deployment.yaml
@@ -68,9 +68,11 @@ spec:
             {{else}}
             secretName: {{ template "kiam.fullname" . }}-server
             {{- end }}
+        {{- if .Values.server.sslCertHostPath }}
         - name: ssl-certs
           hostPath:
             path: {{ .Values.server.sslCertHostPath }}
+        {{- end }}
       {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:
@@ -132,9 +134,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/kiam/tls
               name: tls
+            {{- if .Values.server.sslCertHostPath }}
             - mountPath: /etc/ssl/certs
               name: ssl-certs
               readOnly: true
+            {{- end }}
           {{- range .Values.server.extraHostPathMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -293,6 +293,7 @@ server:
   #   /etc/pki/ca-trust/extracted/pem
   ## else:
   #   /usr/share/ca-certificates
+  # Set to "" to disable host mounting, for example if you're using your own image 
   sslCertHostPath: /usr/share/ca-certificates
 
   ## Additional container hostPath mounts


### PR DESCRIPTION
We're looking to migrate our cluster from CoreOS to FCOS, and they host SSL path differs between the host. This PR will enable us to use our own Kiam image with the certs already added to facilitate the upgrade.