### PR TITLE
Helm chart 3.6

### DIFF
--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Helm Chart Changelog
 
+## 5.9.0
+REPLACEME 2020
+
+Notable changes:
+* [#406](https://github.com/uswitch/kiam/pull/REPLACEME) Update kiam release from 3.5 to 3.6.
+
+Many thanks to the following contributor for this release:
+* [@leosunmo](https://github.com/leosunmo)
+
+## 5.8.1
+12 June 2020
+
+Notable changes:
+* [#406](https://github.com/uswitch/kiam/pull/406) Fix indentation on seLinuxOptions in server daemonset in Helm chart.
+
+Many thanks to the following contributor for this release:
+* [@mbarrien](https://github.com/mbarrien)
+
+
+## 5.8.0
+11 June 2020
+
+Notable changes:
+* [#404](https://github.com/uswitch/kiam/pull/404) Allow for configurable SELinux labels. Adds seLinuxOptions values to the Helm chart for both the agent and server.
+
+Many thanks to the following contributor for this release:
+* [@hfuss](https://github.com/hfuss)
+
+## 5.7.1
+11 June 2020
+
+Notable changes:
+* [#405](https://github.com/uswitch/kiam/pull/405) Fix incorrect indentation in server's pod affinity.
+
+Many thanks to the following contributor for this release:
+* [@msvechla](https://github.com/msvechla)
+
 ## 5.7.0
 5 February 2020
 

--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Helm Chart Changelog
 
 ## 5.9.0
-REPLACEME 2020
+17 August 2020
 
 Notable changes:
 * [#417](https://github.com/uswitch/kiam/pull/417) Update kiam release from 3.5 to 3.6.

--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -4,7 +4,7 @@
 REPLACEME 2020
 
 Notable changes:
-* [#406](https://github.com/uswitch/kiam/pull/REPLACEME) Update kiam release from 3.5 to 3.6.
+* [#417](https://github.com/uswitch/kiam/pull/417) Update kiam release from 3.5 to 3.6.
 
 Many thanks to the following contributor for this release:
 * [@leosunmo](https://github.com/leosunmo)

--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kiam
-version: 5.8.1
-appVersion: 3.5
+version: 5.9.0
+appVersion: 3.6
 description: Integrate AWS IAM with Kubernetes
 keywords:
   - kiam

--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -155,117 +155,117 @@ server:
 
 The following table lists the configurable parameters of the kiam chart and their default values.
 
-Parameter | Description | Default
---- | --- | ---
-`agent.enabled` | If true, create agent | `true`
-`agent.name` | Agent container name | `agent`
-`agent.image.repository` | Agent image | `quay.io/uswitch/kiam`
-`agent.image.tag` | Agent image tag | `v3.5`
-`agent.image.pullPolicy` | Agent image pull policy | `IfNotPresent`
-`agent.dnsPolicy` | Agent pod DNS policy | `ClusterFirstWithHostNet`
-`agent.whiteListRouteRegexp` | Agent pod whitelist metadata API path argument regex  | `{}`
-`agent.extraArgs` | Additional agent container arguments | `{}`
-`agent.extraEnv` | Additional agent container environment variables | `{}`
-`agent.extraHostPathMounts` | Additional agent container hostPath mounts | `[]`
-`agent.initContainers` | Agent initContainers | `[]`
-`agent.gatewayTimeoutCreation` | Agent's timeout when creating the kiam gateway | `1s`
-`agent.keepaliveParams.time` | gRPC keepalive time | `10s`
-`agent.keepaliveParams.timeout` | gRPC keepalive timeout | `2s`
-`agent.keepaliveParams.permitWithoutStream` | gRPC keepalive ping even with no RPC | `false`
-`agent.host.ip` | IP address of host | `$(HOST_IP)`
-`agent.host.iptables` | Add iptables rule | `false`
-`agent.host.interface` | Agent's host interface for proxying AWS metadata | `cali+`
-`agent.host.port` | Agent's listening port | `8181`
-`agent.log.jsonOutput` | Whether or not to output agent log in JSON format | `true`
-`agent.log.level` | Agent log level (`debug`, `info`, `warn` or `error`) | `info`
-`agent.deepLivenessProbe` | Fail liveness probe if the server is not accessible | `false`
-`agent.nodeSelector` | Node labels for agent pod assignment | `{}`
-`agent.prometheus.port` | Agent Prometheus metrics port | `9620`
-`agent.prometheus.scrape` | Whether or not Prometheus metrics for the agent should be scraped | `true`
-`agent.prometheus.syncInterval` | Agent Prometheus synchronization interval | `5s`
-`agent.prometheus.servicemonitor.enabled` | Whether servicemonitor resource should be deployed for the agent | `false`
-`agent.prometheus.servicemonitor.path` | Agent prometheus scrape path | `/metrics`
-`agent.prometheus.servicemonitor.interval` | Agent prometheus scrape interval from servicemonitor | `10s`
-`agent.prometheus.servicemonitor.labels` | Custom labels for agent servicemonitor | `{}`
-`agent.podAnnotations` | Annotations to be added to agent pods | `{}`
-`agent.podLabels` | Labels to be added to agent pods | `{}`
-`agent.priorityClassName` | Agent pods priority class name | `""`
-`agent.resources` | Agent container resources | `{}`
-`agent.seLinuxOptions`  | SELinux labels to be added to the agent container process | `{}`
-`agent.serviceAnnotations` | Annotations to be added to agent service | `{}`
-`agent.serviceLabels` | Labels to be added to agent service | `{}`
-`agent.tlsSecret` | Secret name for the agent's TLS certificates | `null`
-`agent.tlsFiles.ca` | Base64 encoded string for the agent's CA certificate(s) | `null`
-`agent.tlsFiles.cert` | Base64 encoded strings for the agent's certificate | `null`
-`agent.tlsFiles.key` | Base64 encoded strings for the agent's private key | `null`
-`agent.tolerations` | Tolerations to be applied to agent pods | `[]`
-`agent.affinity` | Node affinity for pod assignment | `{}`
-`agent.updateStrategy` | Strategy for agent DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
-`agent.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | 3
-`agent.livenessProbe.periodSeconds` | How often to perform the probe | 3
-`agent.livenessProbe.timeoutSeconds` | When the probe times out | 1
-`agent.livenessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
-`agent.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
-`server.enabled` | If true, create server | `true`
-`server.name` | Server container name | `server`
-`server.gatewayTimeoutCreation` | Server's timeout when creating the kiam gateway | `1s`
-`server.image.repository` | Server image | `quay.io/uswitch/kiam`
-`server.image.tag` | Server image tag | `v3.5`
-`server.image.pullPolicy` | Server image pull policy | `Always`
-`server.assumeRoleArn` | IAM role for the server to assume before processing requests | `null`
-`server.cache.syncInterval` | Pod cache synchronization interval | `1m`
-`server.extraArgs` | Additional server container arguments | `{}`
-`server.extraEnv` | Additional server container environment variables | `{}`
-`server.sslCertHostPath` | Path to SSL certs on host machinee | `/usr/share/ca-certificates`
-`server.extraHostPathMounts` | Additional server container hostPath mounts | `[]`
-`server.initContainers` | Server initContainers | `[]`
-`server.log.jsonOutput` | Whether or not to output server log in JSON format | `true`
-`server.log.level` | Server log level (`debug`, `info`, `warn` or `error`) | `info`
-`server.nodeSelector` | Node labels for server pod assignment | `{}`
-`server.prometheus.port` | Server Prometheus metrics port | `9620`
-`server.prometheus.scrape` | Whether or not Prometheus metrics for the server should be scraped | `true`
-`server.prometheus.syncInterval` | Server Prometheus synchronization interval | `5s`
-`server.prometheus.servicemonitor.enabled` | Whether servicemonitor resource should be deployed for the server | `false`
-`server.prometheus.servicemonitor.path` | Server prometheus scrape path | `/metrics`
-`server.prometheus.servicemonitor.interval` | Server prometheus scrape interval from servicemonitor | `10s`
-`server.prometheus.servicemonitor.labels` | Custom labels for server servicemonitor | `{}`
-`server.podAnnotations` | Annotations to be added to server pods | `{}`
-`server.podLabels` | Labels to be added to server pods | `{}`
-`server.probes.serverAddress` | Address that readyness and liveness probes will hit | `127.0.0.1`
-`server.priorityClassName` | Server pods priority class name | `""`
-`server.resources` | Server container resources | `{}`
-`server.roleBaseArn` | Base ARN for IAM roles. If not specified use EC2 metadata service to detect ARN prefix | `null`
-`server.seLinuxOptions`  | SELinux labels to be added to the server container process | `{}`
-`server.sessionDuration` | Session duration for STS tokens generated by the server | `15m`
-`server.serviceAnnotations` | Annotations to be added to server service | `{}`
-`server.serviceLabels` | Labels to be added to server service | `{}`
-`server.service.port` | Server service port | `443`
-`server.service.targetPort` | Server service target port | `443`
-`server.tlsSecret` | Secret name for the server's TLS certificates | `null`
-`server.tlsFiles.ca` | Base64 encoded string for the server's CA certificate(s) | `null`
-`server.tlsFiles.cert` | Base64 encoded strings for the server's certificate | `null`
-`server.tlsFiles.key` | Base64 encoded strings for the server's private key | `null`
-`server.tolerations` | Tolerations to be applied to server pods | `[]`
-`server.affinity` | Node affinity for pod assignment | `{}`
-`server.updateStrategy` | Strategy for server DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
-`server.useHostNetwork` | If true, use hostNetwork on server to bypass agent iptable rules | `false`
-`server.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | 10
-`server.livenessProbe.periodSeconds` | How often to perform the probe | 10
-`server.livenessProbe.timeoutSeconds` | When the probe times out | 10
-`server.livenessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
-`server.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
-`server.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 10
-`server.readinessProbe.periodSeconds` | How often to perform the probe | 10
-`server.readinessProbe.timeoutSeconds` | When the probe times out | 10
-`server.readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
-`server.readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
-`rbac.create` | If `true`, create & use RBAC resources | `true`
-`psp.create` | If `true`, create Pod Security Policies for the agent and server when enabled | `false`
-`imagePullSecrets` | The name of the secret to use if pulling from a private registry | `nil`
-`serviceAccounts.agent.create` | If true, create the agent service account | `true`
-`serviceAccounts.agent.name` | Name of the agent service account to use or create | `{{ kiam.agent.fullname }}`
-`serviceAccounts.server.create` | If true, create the server service account | `true`
-`serviceAccounts.server.name` | Name of the server service account to use or create | `{{ kiam.server.fullname }}`
+| Parameter                                   | Description                                                                                  | Default                      |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------- |
+| `agent.enabled`                             | If true, create agent                                                                        | `true`                       |
+| `agent.name`                                | Agent container name                                                                         | `agent`                      |
+| `agent.image.repository`                    | Agent image                                                                                  | `quay.io/uswitch/kiam`       |
+| `agent.image.tag`                           | Agent image tag                                                                              | `v3.6`                       |
+| `agent.image.pullPolicy`                    | Agent image pull policy                                                                      | `IfNotPresent`               |
+| `agent.dnsPolicy`                           | Agent pod DNS policy                                                                         | `ClusterFirstWithHostNet`    |
+| `agent.whiteListRouteRegexp`                | Agent pod whitelist metadata API path argument regex                                         | `{}`                         |
+| `agent.extraArgs`                           | Additional agent container arguments                                                         | `{}`                         |
+| `agent.extraEnv`                            | Additional agent container environment variables                                             | `{}`                         |
+| `agent.extraHostPathMounts`                 | Additional agent container hostPath mounts                                                   | `[]`                         |
+| `agent.initContainers`                      | Agent initContainers                                                                         | `[]`                         |
+| `agent.gatewayTimeoutCreation`              | Agent's timeout when creating the kiam gateway                                               | `1s`                         |
+| `agent.keepaliveParams.time`                | gRPC keepalive time                                                                          | `10s`                        |
+| `agent.keepaliveParams.timeout`             | gRPC keepalive timeout                                                                       | `2s`                         |
+| `agent.keepaliveParams.permitWithoutStream` | gRPC keepalive ping even with no RPC                                                         | `false`                      |
+| `agent.host.ip`                             | IP address of host                                                                           | `$(HOST_IP)`                 |
+| `agent.host.iptables`                       | Add iptables rule                                                                            | `false`                      |
+| `agent.host.interface`                      | Agent's host interface for proxying AWS metadata                                             | `cali+`                      |
+| `agent.host.port`                           | Agent's listening port                                                                       | `8181`                       |
+| `agent.log.jsonOutput`                      | Whether or not to output agent log in JSON format                                            | `true`                       |
+| `agent.log.level`                           | Agent log level (`debug`, `info`, `warn` or `error`)                                         | `info`                       |
+| `agent.deepLivenessProbe`                   | Fail liveness probe if the server is not accessible                                          | `false`                      |
+| `agent.nodeSelector`                        | Node labels for agent pod assignment                                                         | `{}`                         |
+| `agent.prometheus.port`                     | Agent Prometheus metrics port                                                                | `9620`                       |
+| `agent.prometheus.scrape`                   | Whether or not Prometheus metrics for the agent should be scraped                            | `true`                       |
+| `agent.prometheus.syncInterval`             | Agent Prometheus synchronization interval                                                    | `5s`                         |
+| `agent.prometheus.servicemonitor.enabled`   | Whether servicemonitor resource should be deployed for the agent                             | `false`                      |
+| `agent.prometheus.servicemonitor.path`      | Agent prometheus scrape path                                                                 | `/metrics`                   |
+| `agent.prometheus.servicemonitor.interval`  | Agent prometheus scrape interval from servicemonitor                                         | `10s`                        |
+| `agent.prometheus.servicemonitor.labels`    | Custom labels for agent servicemonitor                                                       | `{}`                         |
+| `agent.podAnnotations`                      | Annotations to be added to agent pods                                                        | `{}`                         |
+| `agent.podLabels`                           | Labels to be added to agent pods                                                             | `{}`                         |
+| `agent.priorityClassName`                   | Agent pods priority class name                                                               | `""`                         |
+| `agent.resources`                           | Agent container resources                                                                    | `{}`                         |
+| `agent.seLinuxOptions`                      | SELinux labels to be added to the agent container process                                    | `{}`                         |
+| `agent.serviceAnnotations`                  | Annotations to be added to agent service                                                     | `{}`                         |
+| `agent.serviceLabels`                       | Labels to be added to agent service                                                          | `{}`                         |
+| `agent.tlsSecret`                           | Secret name for the agent's TLS certificates                                                 | `null`                       |
+| `agent.tlsFiles.ca`                         | Base64 encoded string for the agent's CA certificate(s)                                      | `null`                       |
+| `agent.tlsFiles.cert`                       | Base64 encoded strings for the agent's certificate                                           | `null`                       |
+| `agent.tlsFiles.key`                        | Base64 encoded strings for the agent's private key                                           | `null`                       |
+| `agent.tolerations`                         | Tolerations to be applied to agent pods                                                      | `[]`                         |
+| `agent.affinity`                            | Node affinity for pod assignment                                                             | `{}`                         |
+| `agent.updateStrategy`                      | Strategy for agent DaemonSet updates (requires Kubernetes 1.6+)                              | `OnDelete`                   |
+| `agent.livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                     | 3                            |
+| `agent.livenessProbe.periodSeconds`         | How often to perform the probe                                                               | 3                            |
+| `agent.livenessProbe.timeoutSeconds`        | When the probe times out                                                                     | 1                            |
+| `agent.livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                            |
+| `agent.livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                            |
+| `server.enabled`                            | If true, create server                                                                       | `true`                       |
+| `server.name`                               | Server container name                                                                        | `server`                     |
+| `server.gatewayTimeoutCreation`             | Server's timeout when creating the kiam gateway                                              | `1s`                         |
+| `server.image.repository`                   | Server image                                                                                 | `quay.io/uswitch/kiam`       |
+| `server.image.tag`                          | Server image tag                                                                             | `v3.6`                       |
+| `server.image.pullPolicy`                   | Server image pull policy                                                                     | `Always`                     |
+| `server.assumeRoleArn`                      | IAM role for the server to assume before processing requests                                 | `null`                       |
+| `server.cache.syncInterval`                 | Pod cache synchronization interval                                                           | `1m`                         |
+| `server.extraArgs`                          | Additional server container arguments                                                        | `{}`                         |
+| `server.extraEnv`                           | Additional server container environment variables                                            | `{}`                         |
+| `server.sslCertHostPath`                    | Path to SSL certs on host machinee                                                           | `/usr/share/ca-certificates` |
+| `server.extraHostPathMounts`                | Additional server container hostPath mounts                                                  | `[]`                         |
+| `server.initContainers`                     | Server initContainers                                                                        | `[]`                         |
+| `server.log.jsonOutput`                     | Whether or not to output server log in JSON format                                           | `true`                       |
+| `server.log.level`                          | Server log level (`debug`, `info`, `warn` or `error`)                                        | `info`                       |
+| `server.nodeSelector`                       | Node labels for server pod assignment                                                        | `{}`                         |
+| `server.prometheus.port`                    | Server Prometheus metrics port                                                               | `9620`                       |
+| `server.prometheus.scrape`                  | Whether or not Prometheus metrics for the server should be scraped                           | `true`                       |
+| `server.prometheus.syncInterval`            | Server Prometheus synchronization interval                                                   | `5s`                         |
+| `server.prometheus.servicemonitor.enabled`  | Whether servicemonitor resource should be deployed for the server                            | `false`                      |
+| `server.prometheus.servicemonitor.path`     | Server prometheus scrape path                                                                | `/metrics`                   |
+| `server.prometheus.servicemonitor.interval` | Server prometheus scrape interval from servicemonitor                                        | `10s`                        |
+| `server.prometheus.servicemonitor.labels`   | Custom labels for server servicemonitor                                                      | `{}`                         |
+| `server.podAnnotations`                     | Annotations to be added to server pods                                                       | `{}`                         |
+| `server.podLabels`                          | Labels to be added to server pods                                                            | `{}`                         |
+| `server.probes.serverAddress`               | Address that readyness and liveness probes will hit                                          | `127.0.0.1`                  |
+| `server.priorityClassName`                  | Server pods priority class name                                                              | `""`                         |
+| `server.resources`                          | Server container resources                                                                   | `{}`                         |
+| `server.roleBaseArn`                        | Base ARN for IAM roles. If not specified use EC2 metadata service to detect ARN prefix       | `null`                       |
+| `server.seLinuxOptions`                     | SELinux labels to be added to the server container process                                   | `{}`                         |
+| `server.sessionDuration`                    | Session duration for STS tokens generated by the server                                      | `15m`                        |
+| `server.serviceAnnotations`                 | Annotations to be added to server service                                                    | `{}`                         |
+| `server.serviceLabels`                      | Labels to be added to server service                                                         | `{}`                         |
+| `server.service.port`                       | Server service port                                                                          | `443`                        |
+| `server.service.targetPort`                 | Server service target port                                                                   | `443`                        |
+| `server.tlsSecret`                          | Secret name for the server's TLS certificates                                                | `null`                       |
+| `server.tlsFiles.ca`                        | Base64 encoded string for the server's CA certificate(s)                                     | `null`                       |
+| `server.tlsFiles.cert`                      | Base64 encoded strings for the server's certificate                                          | `null`                       |
+| `server.tlsFiles.key`                       | Base64 encoded strings for the server's private key                                          | `null`                       |
+| `server.tolerations`                        | Tolerations to be applied to server pods                                                     | `[]`                         |
+| `server.affinity`                           | Node affinity for pod assignment                                                             | `{}`                         |
+| `server.updateStrategy`                     | Strategy for server DaemonSet updates (requires Kubernetes 1.6+)                             | `OnDelete`                   |
+| `server.useHostNetwork`                     | If true, use hostNetwork on server to bypass agent iptable rules                             | `false`                      |
+| `server.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                     | 10                           |
+| `server.livenessProbe.periodSeconds`        | How often to perform the probe                                                               | 10                           |
+| `server.livenessProbe.timeoutSeconds`       | When the probe times out                                                                     | 10                           |
+| `server.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                            |
+| `server.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                            |
+| `server.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                    | 10                           |
+| `server.readinessProbe.periodSeconds`       | How often to perform the probe                                                               | 10                           |
+| `server.readinessProbe.timeoutSeconds`      | When the probe times out                                                                     | 10                           |
+| `server.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                            |
+| `server.readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                            |
+| `rbac.create`                               | If `true`, create & use RBAC resources                                                       | `true`                       |
+| `psp.create`                                | If `true`, create Pod Security Policies for the agent and server when enabled                | `false`                      |
+| `imagePullSecrets`                          | The name of the secret to use if pulling from a private registry                             | `nil`                        |
+| `serviceAccounts.agent.create`              | If true, create the agent service account                                                    | `true`                       |
+| `serviceAccounts.agent.name`                | Name of the agent service account to use or create                                           | `{{ kiam.agent.fullname }}`  |
+| `serviceAccounts.server.create`             | If true, create the server service account                                                   | `true`                       |
+| `serviceAccounts.server.name`               | Name of the server service account to use or create                                          | `{{ kiam.server.fullname }}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -15,7 +15,7 @@ agent:
 
   image:
     repository: quay.io/uswitch/kiam
-    tag: v3.5
+    tag: v3.6
     pullPolicy: IfNotPresent
 
   ## agent whitelist of proxy routes matching this reg-ex
@@ -201,7 +201,7 @@ server:
 
   image:
     repository: quay.io/uswitch/kiam
-    tag: v3.5
+    tag: v3.6
     pullPolicy: IfNotPresent
 
   ## Run as Deployment instead of Daemonset


### PR DESCRIPTION
This updates the Helm chart's default values to use kiam v3.6.

Reading through the v3.6 release it didn't look like any modifications needed to be done to the Helm charts values other than bumping image tags.

I made the default values readable in raw text form.

I also backfilled the changelog as the gaps were annoying me!

Make sure to replace placeholders in changelog before merging. Maintainers, feel free to push directly to the PR with any changes.