### PR TITLE
Refactoring credentials cache to aid in easier support for session-name and external-id

### DIFF
--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -114,7 +114,7 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *Cre
 
 		if err != nil {
 			logger.Errorf("error retrieving credentials in cache from future: %s. will delete", err.Error())
-			c.cache.Delete(identity.Role)
+			c.cache.Delete(identity.String())
 			return nil, err
 		}
 
@@ -148,7 +148,7 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *Cre
 
 	val, err := f.Get(ctx)
 	if err != nil {
-		c.cache.Delete(identity.Role)
+		c.cache.Delete(identity.String())
 		return nil, err
 	}
 

--- a/pkg/aws/sts/credentials_cache_test.go
+++ b/pkg/aws/sts/credentials_cache_test.go
@@ -36,12 +36,12 @@ func TestRequestsCredentialsFromGatewayWithEmptyCache(t *testing.T) {
 	cache := DefaultCache(stubGateway, "session", 15*time.Minute, 5*time.Minute, DefaultResolver("prefix:"))
 	ctx := context.Background()
 
-	creds, _ := cache.CredentialsForRole(ctx, "role")
+	creds, _ := cache.CredentialsForRole(ctx, &CredentialsIdentity{Role: "role"})
 	if creds.Code != "foo" {
 		t.Error("didnt return expected credentials code, was", creds.Code)
 	}
 
-	cache.CredentialsForRole(ctx, "role")
+	cache.CredentialsForRole(ctx, &CredentialsIdentity{Role: "role"})
 	if stubGateway.issueCount != 1 {
 		t.Error("expected creds to be cached")
 	}

--- a/pkg/aws/sts/interfaces.go
+++ b/pkg/aws/sts/interfaces.go
@@ -18,12 +18,12 @@ import (
 )
 
 type CredentialsProvider interface {
-	CredentialsForRole(ctx context.Context, role string) (*Credentials, error)
+	CredentialsForRole(ctx context.Context, identity *CredentialsIdentity) (*Credentials, error)
 }
 
 type CredentialsCache interface {
-	CredentialsForRole(ctx context.Context, role string) (*Credentials, error)
-	Expiring() chan *RoleCredentials
+	CredentialsForRole(ctx context.Context, identity *CredentialsIdentity) (*Credentials, error)
+	Expiring() chan *CachedCredentials
 }
 
 // ARNResolver encapsulates resolution of roles into ARNs.

--- a/pkg/aws/sts/log.go
+++ b/pkg/aws/sts/log.go
@@ -17,10 +17,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func CredentialsFields(creds *Credentials, role string) log.Fields {
+func CredentialsFields(identity *CredentialsIdentity, creds *Credentials) log.Fields {
 	return log.Fields{
 		"credentials.access.key": creds.AccessKeyId,
 		"credentials.expiration": creds.Expiration,
-		"credentials.role":       role,
+		"credentials.role":       identity.Role,
 	}
 }

--- a/pkg/prefetch/manager_test.go
+++ b/pkg/prefetch/manager_test.go
@@ -15,13 +15,14 @@ package prefetch
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/fortytw2/leaktest"
 	"github.com/uswitch/kiam/pkg/aws/sts"
 	kt "github.com/uswitch/kiam/pkg/k8s/testing"
 	"github.com/uswitch/kiam/pkg/statsd"
 	"github.com/uswitch/kiam/pkg/testutil"
-	"testing"
-	"time"
 )
 
 func init() {
@@ -36,8 +37,8 @@ func TestPrefetchRunningPods(t *testing.T) {
 
 	requestedRoles := make(chan string)
 	announcer := kt.NewStubAnnouncer()
-	cache := testutil.NewStubCredentialsCache(func(role string) (*sts.Credentials, error) {
-		requestedRoles <- role
+	cache := testutil.NewStubCredentialsCache(func(identity *sts.CredentialsIdentity) (*sts.Credentials, error) {
+		requestedRoles <- identity.Role
 		return &sts.Credentials{}, nil
 	})
 	manager := NewManager(cache, announcer)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -116,7 +116,7 @@ func (k *KiamServer) GetPodCredentials(ctx context.Context, req *pb.GetPodCreden
 		return nil, ErrPolicyForbidden
 	}
 
-	creds, err := k.credentialsProvider.CredentialsForRole(ctx, req.Role)
+	creds, err := k.credentialsProvider.CredentialsForRole(ctx, &sts.CredentialsIdentity{Role: req.Role})
 	if err != nil {
 		logger.Errorf("error retrieving credentials: %s", err.Error())
 		k.recordEvent(pod, v1.EventTypeWarning, "KiamCredentialError", fmt.Sprintf("failed retrieving credentials: %s", simplifyAWSErrorMessage(err)))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3,6 +3,9 @@ package server
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/fortytw2/leaktest"
 	"github.com/uswitch/kiam/pkg/aws/sts"
@@ -11,8 +14,6 @@ import (
 	"github.com/uswitch/kiam/pkg/testutil"
 	pb "github.com/uswitch/kiam/proto"
 	kt "k8s.io/client-go/tools/cache/testing"
-	"testing"
-	"time"
 )
 
 const (
@@ -106,7 +107,7 @@ type stubCredentialsProvider struct {
 	accessKey string
 }
 
-func (c *stubCredentialsProvider) CredentialsForRole(ctx context.Context, role string) (*sts.Credentials, error) {
+func (c *stubCredentialsProvider) CredentialsForRole(ctx context.Context, identity *sts.CredentialsIdentity) (*sts.Credentials, error) {
 	return &sts.Credentials{
 		AccessKeyId: c.accessKey,
 	}, nil

--- a/pkg/testutil/issuer.go
+++ b/pkg/testutil/issuer.go
@@ -15,21 +15,22 @@ package testutil
 
 import (
 	"context"
+
 	"github.com/uswitch/kiam/pkg/aws/sts"
 )
 
 type stubCache struct {
-	issue func(role string) (*sts.Credentials, error)
+	issue func(identity *sts.CredentialsIdentity) (*sts.Credentials, error)
 }
 
-func (i *stubCache) CredentialsForRole(ctx context.Context, role string) (*sts.Credentials, error) {
-	return i.issue(role)
+func (i *stubCache) CredentialsForRole(ctx context.Context, identity *sts.CredentialsIdentity) (*sts.Credentials, error) {
+	return i.issue(identity)
 }
 
-func (i *stubCache) Expiring() chan *sts.RoleCredentials {
-	return make(chan *sts.RoleCredentials)
+func (i *stubCache) Expiring() chan *sts.CachedCredentials {
+	return make(chan *sts.CachedCredentials)
 }
 
-func NewStubCredentialsCache(f func(role string) (*sts.Credentials, error)) sts.CredentialsCache {
+func NewStubCredentialsCache(f func(identity *sts.CredentialsIdentity) (*sts.Credentials, error)) sts.CredentialsCache {
 	return &stubCache{f}
 }


### PR DESCRIPTION
This PR begins work towards supporting external-id and session-name by refactoring the caching layer to easier support things moving forward.

It introduces a struct `CredentialsIdentity` that will contain the role/session-name/extrernal-id and a function to generate the cache key. It also changes the cache to hold the `CachedCredentials` item so that expiry can get the identity it needs to refresh the role when required.

With this merged I will move onto the implementation for external-id and session-name support.