### PR TITLE
Add support for external-id and session-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ metadata:
     iam.amazonaws.com/role: reportingdb-reader
 ```
 
+You can control the session name used when assuming the role via an annotation added to the `Pod`, which may be used to further identify the session. For example:
+
+```yaml
+kind: Pod
+metadata:
+  name: foo
+  namespace: session-name-example
+  annotations:
+    iam.amazonaws.com/role: reportingdb-reader
+    iam.amazonaws.com/session-name: my-session-name
+```
+
+You can also control the external id used when assuming the role via an annotation added to the `Pod`, which
+maybe used to avoid [confused deputy scenarios in cross-organisation role assumption](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html). For example:
+
+```yaml
+kind: Pod
+metadata:
+  name: foo
+  namespace: external-id-example
+  annotations:
+    iam.amazonaws.com/role: reportingdb-reader
+    iam.amazonaws.com/external-id: dac7ad46-acab-4ec3-a78e-f3962ecf45d7
+```
+
 Further, all namespaces must also have an annotation with a regular expression expressing which roles are permitted to be assumed within that namespace. **Without the namespace annotation the pod will be unable to assume any roles.**
 
 ```yaml

--- a/pkg/aws/sts/arn_resolver.go
+++ b/pkg/aws/sts/arn_resolver.go
@@ -22,6 +22,11 @@ type Resolver struct {
 	prefix string
 }
 
+type ResolvedRole struct {
+	Name string
+	ARN  string
+}
+
 // DefaultResolver will add the prefix to any roles which
 // don't start with arn:
 func DefaultResolver(prefix string) *Resolver {
@@ -29,24 +34,28 @@ func DefaultResolver(prefix string) *Resolver {
 }
 
 // Resolve converts from a role string into the absolute role arn.
-func (r *Resolver) Resolve(role string) (*RoleIdentity, error) {
+func (r *Resolver) Resolve(role string) (*ResolvedRole, error) {
 	if role == "" {
 		return nil, fmt.Errorf("role can't be empty")
 	}
 
 	if strings.HasPrefix(role, "arn:") {
-		return &RoleIdentity{ARN: role, Role: roleFromArn(role)}, nil
+		return &ResolvedRole{ARN: role, Name: roleFromArn(role)}, nil
 	}
 
 	if strings.HasPrefix(role, "/") {
 		role = strings.TrimPrefix(role, "/")
 	}
 
-	return &RoleIdentity{ARN: fmt.Sprintf("%s%s", r.prefix, role), Role: role}, nil
+	return &ResolvedRole{ARN: fmt.Sprintf("%s%s", r.prefix, role), Name: role}, nil
 }
 
 // arn:aws:iam::account-id:role/role-name-with-path
 func roleFromArn(arn string) string {
 	splits := strings.SplitAfterN(arn, ":", 6)
 	return strings.TrimPrefix(splits[5], "role/")
+}
+
+func (i *ResolvedRole) Equals(other *ResolvedRole) bool {
+	return *i == *other
 }

--- a/pkg/aws/sts/arn_resolver_test.go
+++ b/pkg/aws/sts/arn_resolver_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 )
 
-func TestRoleIdentityEquality(t *testing.T) {
+func TestResolvedRoleEquality(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
 	i1, _ := resolver.Resolve("foo")
 	i2, _ := resolver.Resolve("foo")
@@ -34,10 +34,10 @@ func TestRoleIdentityEquality(t *testing.T) {
 
 func TestAddsPrefix(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	identity, _ := resolver.Resolve("myrole")
+	resolvedRole, _ := resolver.Resolve("myrole")
 
-	if identity.ARN != "arn:aws:iam::account-id:role/myrole" {
-		t.Error("unexpected role, was:", identity.ARN)
+	if resolvedRole.ARN != "arn:aws:iam::account-id:role/myrole" {
+		t.Error("unexpected role, was:", resolvedRole.ARN)
 	}
 }
 
@@ -52,47 +52,47 @@ func TestReturnsErrorForEmptyRole(t *testing.T) {
 
 func TestAddsPrefixWithRoleBeginningWithSlash(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	identity, _ := resolver.Resolve("/myrole")
+	resolvedRole, _ := resolver.Resolve("/myrole")
 
-	if identity.ARN != "arn:aws:iam::account-id:role/myrole" {
-		t.Error("unexpected role, was:", identity.ARN)
+	if resolvedRole.ARN != "arn:aws:iam::account-id:role/myrole" {
+		t.Error("unexpected role, was:", resolvedRole.ARN)
 	}
 
-	if identity.Role != "myrole" {
-		t.Error("unexpected role, was", identity.Role)
+	if resolvedRole.Name != "myrole" {
+		t.Error("unexpected role, was", resolvedRole.Name)
 	}
 }
 func TestAddsPrefixWithRoleBeginningWithPathWithoutSlash(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	identity, _ := resolver.Resolve("kiam/myrole")
+	resolvedRole, _ := resolver.Resolve("kiam/myrole")
 
-	if identity.ARN != "arn:aws:iam::account-id:role/kiam/myrole" {
-		t.Error("unexpected role, was:", identity.ARN)
+	if resolvedRole.ARN != "arn:aws:iam::account-id:role/kiam/myrole" {
+		t.Error("unexpected role, was:", resolvedRole.ARN)
 	}
 
-	if identity.Role != "kiam/myrole" {
-		t.Error("unexpected role", identity.Role)
+	if resolvedRole.Name != "kiam/myrole" {
+		t.Error("unexpected role", resolvedRole.Name)
 	}
 }
 func TestAddsPrefixWithRoleBeginningWithSlashPath(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	identity, _ := resolver.Resolve("/kiam/myrole")
+	resolvedRole, _ := resolver.Resolve("/kiam/myrole")
 
-	if identity.ARN != "arn:aws:iam::account-id:role/kiam/myrole" {
-		t.Error("unexpected role, was:", identity.ARN)
+	if resolvedRole.ARN != "arn:aws:iam::account-id:role/kiam/myrole" {
+		t.Error("unexpected role, was:", resolvedRole.ARN)
 	}
 }
 
 func TestUsesAbsoluteARN(t *testing.T) {
 	resolver := DefaultResolver("arn:aws:iam::account-id:role/")
-	identity, _ := resolver.Resolve("arn:aws:iam::some-other-account:role/path-prefix/another-role")
+	resolvedRole, _ := resolver.Resolve("arn:aws:iam::some-other-account:role/path-prefix/another-role")
 
-	if identity.ARN != "arn:aws:iam::some-other-account:role/path-prefix/another-role" {
-		t.Error("unexpected role, was:", identity.ARN)
+	if resolvedRole.ARN != "arn:aws:iam::some-other-account:role/path-prefix/another-role" {
+		t.Error("unexpected role, was:", resolvedRole.ARN)
 	}
 
-	if identity.Role != "path-prefix/another-role" {
-		t.Error("expected role to be set, was", identity.Role)
+	if resolvedRole.Name != "path-prefix/another-role" {
+		t.Error("expected role to be set, was", resolvedRole.Name)
 	}
 }
 

--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -35,12 +35,6 @@ type credentialsCache struct {
 	gateway         STSGateway
 }
 
-type RoleIdentity struct {
-	Role        ResolvedRole
-	SessionName string
-	ExternalID  string
-}
-
 type CachedCredentials struct {
 	Identity    *RoleIdentity
 	Credentials *Credentials
@@ -155,17 +149,6 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *Rol
 
 	cachedCreds := val.(*CachedCredentials)
 	return cachedCreds.Credentials, nil
-}
-
-func (i *RoleIdentity) String() string {
-	return fmt.Sprintf("%s|%s|%s", i.Role.ARN, i.SessionName, i.ExternalID)
-}
-
-func (i *RoleIdentity) LogFields() log.Fields {
-	return log.Fields{
-		"pod.iam.role":    i.Role,
-		"pod.iam.roleArn": i.Role.ARN,
-	}
 }
 
 func (c *credentialsCache) getSessionName(identity *RoleIdentity) string {

--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -16,6 +16,7 @@ package sts
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -35,8 +36,9 @@ type credentialsCache struct {
 }
 
 type RoleIdentity struct {
-	Role string
-	ARN  string // Amazon Resource Name for the Role
+	Role        ResolvedRole
+	SessionName string
+	ExternalID  string
 }
 
 type CachedCredentials struct {
@@ -56,7 +58,7 @@ func DefaultCache(
 ) *credentialsCache {
 	c := &credentialsCache{
 		expiring:        make(chan *CachedCredentials, 1),
-		sessionName:     fmt.Sprintf("kiam-%s", sessionName),
+		sessionName:     sessionName,
 		sessionDuration: sessionDuration,
 		cacheTTL:        sessionDuration - sessionRefresh,
 		gateway:         gateway,
@@ -95,7 +97,7 @@ func (c *credentialsCache) Expiring() chan *CachedCredentials {
 // CredentialsForRole looks for cached credentials or requests them from the STSGateway. Requested credentials
 // must have their ARN set.
 func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *RoleIdentity) (*Credentials, error) {
-	logger := log.WithFields(log.Fields{"pod.iam.role": identity.Role, "pod.iam.roleArn": identity.ARN})
+	logger := log.WithFields(identity.LogFields())
 	item, found := c.cache.Get(identity.String())
 
 	if found {
@@ -117,7 +119,16 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *Rol
 	cacheMiss.Inc()
 
 	issue := func() (interface{}, error) {
-		credentials, err := c.gateway.Issue(ctx, identity.ARN, c.sessionName, c.sessionDuration)
+		sessionName := c.getSessionName(identity)
+
+		stsIssueRequest := &STSIssueRequest{
+			RoleARN:         identity.Role.ARN,
+			SessionName:     sessionName,
+			ExternalID:      identity.ExternalID,
+			SessionDuration: c.sessionDuration,
+		}
+
+		credentials, err := c.gateway.Issue(ctx, stsIssueRequest)
 		if err != nil {
 			errorIssuing.Inc()
 			logger.Errorf("error requesting credentials: %s", err.Error())
@@ -147,9 +158,36 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *Rol
 }
 
 func (i *RoleIdentity) String() string {
-	return i.ARN
+	return fmt.Sprintf("%s|%s|%s", i.Role.ARN, i.SessionName, i.ExternalID)
 }
 
-func (i *RoleIdentity) Equals(other *RoleIdentity) bool {
-	return *i == *other
+func (i *RoleIdentity) LogFields() log.Fields {
+	return log.Fields{
+		"pod.iam.role":    i.Role,
+		"pod.iam.roleArn": i.Role.ARN,
+	}
+}
+
+func (c *credentialsCache) getSessionName(identity *RoleIdentity) string {
+	sessionName := c.sessionName
+
+	if identity.SessionName != "" {
+		sessionName = identity.SessionName
+	}
+
+	sessionName = fmt.Sprintf("kiam-%s", sessionName)
+	return sanitizeSessionName(sessionName)
+}
+
+// Ensure the session name meets length requirements and
+// also coercce any character that doens't meet the pattern
+// requirements to a hyhen so that we ensure a valid session name.
+func sanitizeSessionName(sessionName string) string {
+	sanitize := regexp.MustCompile(`([^\w+=,.@-])`)
+
+	if len(sessionName) > 64 {
+		sessionName = sessionName[0:63]
+	}
+
+	return sanitize.ReplaceAllString(sessionName, "-")
 }

--- a/pkg/aws/sts/interfaces.go
+++ b/pkg/aws/sts/interfaces.go
@@ -28,5 +28,5 @@ type CredentialsCache interface {
 
 // ARNResolver encapsulates resolution of roles into ARNs.
 type ARNResolver interface {
-	Resolve(role string) (*RoleIdentity, error)
+	Resolve(role string) (*ResolvedRole, error)
 }

--- a/pkg/aws/sts/role_identity.go
+++ b/pkg/aws/sts/role_identity.go
@@ -1,0 +1,37 @@
+package sts
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type RoleIdentity struct {
+	Role        ResolvedRole
+	SessionName string
+	ExternalID  string
+}
+
+func NewRoleIdentity(arnResolver ARNResolver, role, sessionName, externalID string) (*RoleIdentity, error) {
+	resolvedRole, err := arnResolver.Resolve(role)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RoleIdentity{
+		Role:        *resolvedRole,
+		SessionName: sessionName,
+		ExternalID:  externalID,
+	}, nil
+}
+
+func (i *RoleIdentity) String() string {
+	return fmt.Sprintf("%s|%s|%s", i.Role.ARN, i.SessionName, i.ExternalID)
+}
+
+func (i *RoleIdentity) LogFields() log.Fields {
+	return log.Fields{
+		"pod.iam.role":    i.Role,
+		"pod.iam.roleArn": i.Role.ARN,
+	}
+}

--- a/pkg/k8s/interfaces.go
+++ b/pkg/k8s/interfaces.go
@@ -15,7 +15,9 @@ package k8s
 
 import (
 	"context"
-	"k8s.io/api/core/v1"
+
+	"github.com/uswitch/kiam/pkg/aws/sts"
+	v1 "k8s.io/api/core/v1"
 )
 
 type PodGetter interface {
@@ -26,7 +28,7 @@ type PodAnnouncer interface {
 	// Will receive a Pod whenever there's a change/addition for a Pod with a role.
 	Pods() <-chan *v1.Pod
 	// Return whether there are still uncompleted pods in the specified role
-	IsActivePodsForRole(role string) (bool, error)
+	IsActivePodsForRole(identity *sts.RoleIdentity) (bool, error)
 }
 
 type NamespaceFinder interface {

--- a/pkg/k8s/pod_cache.go
+++ b/pkg/k8s/pod_cache.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -180,8 +180,24 @@ func PodRole(pod *v1.Pod) string {
 	return pod.ObjectMeta.Annotations[AnnotationIAMRoleKey]
 }
 
+// PodSessionName returns the IAM role session-name specified in the annotation for the Pod
+func PodSessionName(pod *v1.Pod) string {
+	return pod.ObjectMeta.Annotations[AnnotationIAMSessionNameKey]
+}
+
+// PodExternalID returns the IAM role external-id specified in the annotation for the Pod
+func PodExternalID(pod *v1.Pod) string {
+	return pod.ObjectMeta.Annotations[AnnotationIAMExternalIDKey]
+}
+
 // AnnotationIAMRoleKey is the key for the annotation specifying the IAM Role
 const AnnotationIAMRoleKey = "iam.amazonaws.com/role"
+
+// AnnotationIAMSessionNameKey is the key for the annotation specifying the session-name
+const AnnotationIAMSessionNameKey = "iam.amazonaws.com/session-name"
+
+// AnnotationIAMExternalIDKey is the key for the annotation specifying the external-id
+const AnnotationIAMExternalIDKey = "iam.amazonaws.com/external-id"
 
 type podHandler struct {
 	pods chan<- *v1.Pod

--- a/pkg/k8s/pod_cache.go
+++ b/pkg/k8s/pod_cache.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/uswitch/kiam/pkg/aws/sts"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -34,10 +35,10 @@ type PodCache struct {
 // IP address so that Kiam can identify which role a Pod should assume. It periodically syncs the list of
 // pods and can announce Pods. When announcing Pods via the channel it will drop events if the buffer
 // is full- bufferSize determines how many.
-func NewPodCache(source cache.ListerWatcher, syncInterval time.Duration, bufferSize int) *PodCache {
+func NewPodCache(arnResolver sts.ARNResolver, source cache.ListerWatcher, syncInterval time.Duration, bufferSize int) *PodCache {
 	indexers := cache.Indexers{
-		indexPodIP:   podIPIndex,
-		indexPodRole: podRoleIndex,
+		indexPodIP:           podIPIndex,
+		indexPodRoleIdentity: podRoleIdentityIndex(arnResolver),
 	}
 	pods := make(chan *v1.Pod, bufferSize)
 	podHandler := &podHandler{pods}
@@ -70,8 +71,8 @@ func (s *PodCache) Pods() <-chan *v1.Pod {
 // using the provided role. This is used to identify whether the
 // role credentials should be maintained. Part of the PodAnnouncer
 // interface
-func (s *PodCache) IsActivePodsForRole(role string) (bool, error) {
-	items, err := s.indexer.ByIndex(indexPodRole, role)
+func (s *PodCache) IsActivePodsForRole(identity *sts.RoleIdentity) (bool, error) {
+	items, err := s.indexer.ByIndex(indexPodRoleIdentity, identity.String())
 	if err != nil {
 		return false, err
 	}
@@ -138,8 +139,8 @@ func (s *PodCache) GetPodByIP(ip string) (*v1.Pod, error) {
 }
 
 const (
-	indexPodIP   = "byIP"
-	indexPodRole = "byRole"
+	indexPodIP           = "byIP"
+	indexPodRoleIdentity = "byRoleIdentity"
 )
 
 func podIPIndex(obj interface{}) ([]string, error) {
@@ -152,14 +153,23 @@ func podIPIndex(obj interface{}) ([]string, error) {
 	return []string{pod.Status.PodIP}, nil
 }
 
-func podRoleIndex(obj interface{}) ([]string, error) {
-	pod := obj.(*v1.Pod)
-	role := PodRole(pod)
-	if role == "" {
-		return []string{}, nil
-	}
+func podRoleIdentityIndex(arnResolver sts.ARNResolver) func(obj interface{}) ([]string, error) {
+	return func(obj interface{}) ([]string, error) {
+		pod := obj.(*v1.Pod)
+		role := PodRole(pod)
+		if role == "" {
+			return []string{}, nil
+		}
 
-	return []string{role}, nil
+		sessionName := PodSessionName(pod)
+		externalID := PodExternalID(pod)
+		identity, err := sts.NewRoleIdentity(arnResolver, role, sessionName, externalID)
+		if err != nil {
+			return nil, err
+		}
+
+		return []string{identity.String()}, nil
+	}
 }
 
 // Run starts the controller processing updates. Blocks until the cache has synced

--- a/pkg/k8s/testing/stub_finder.go
+++ b/pkg/k8s/testing/stub_finder.go
@@ -15,8 +15,10 @@ package testing
 
 import (
 	"context"
+
+	"github.com/uswitch/kiam/pkg/aws/sts"
 	"github.com/uswitch/kiam/pkg/k8s"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func NewStubFinder(pod *v1.Pod) *StubFinder {
@@ -51,7 +53,7 @@ func (f *stubAnnouncer) Pods() <-chan *v1.Pod {
 	return f.pods
 }
 
-func (f *stubAnnouncer) IsActivePodsForRole(role string) (bool, error) {
+func (f *stubAnnouncer) IsActivePodsForRole(identity *sts.RoleIdentity) (bool, error) {
 	return true, nil
 }
 

--- a/pkg/prefetch/manager.go
+++ b/pkg/prefetch/manager.go
@@ -86,7 +86,7 @@ func (m *CredentialManager) Run(ctx context.Context, parallelRoutines int) {
 func (m *CredentialManager) handleExpiring(ctx context.Context, credentials *sts.CachedCredentials) {
 	logger := log.WithFields(sts.CredentialsFields(credentials.Identity, credentials.Credentials))
 
-	active, err := m.IsRoleActive(credentials.Identity.Role.Name)
+	active, err := m.IsRoleActive(credentials.Identity)
 	if err != nil {
 		logger.Errorf("error checking whether role active: %s", err.Error())
 		return
@@ -104,6 +104,6 @@ func (m *CredentialManager) handleExpiring(ctx context.Context, credentials *sts
 	}
 }
 
-func (m *CredentialManager) IsRoleActive(role string) (bool, error) {
-	return m.announcer.IsActivePodsForRole(role)
+func (m *CredentialManager) IsRoleActive(identity *sts.RoleIdentity) (bool, error) {
+	return m.announcer.IsActivePodsForRole(identity)
 }

--- a/pkg/server/policy.go
+++ b/pkg/server/policy.go
@@ -17,8 +17,9 @@ package server
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"regexp"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/uswitch/kiam/pkg/aws/sts"
 	"github.com/uswitch/kiam/pkg/k8s"
@@ -81,7 +82,7 @@ func (p *RequestingAnnotatedRolePolicy) IsAllowedAssumeRole(ctx context.Context,
 		return &allowed{}, nil
 	}
 
-	return &forbidden{requested: role, annotated: annotatedIdentiy.Role}, nil
+	return &forbidden{requested: role, annotated: annotatedIdentiy.Name}, nil
 }
 
 type NamespacePermittedRoleNamePolicy struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -105,10 +105,17 @@ func (k *KiamServer) GetPodCredentials(ctx context.Context, req *pb.GetPodCreden
 		return nil, ErrPolicyForbidden
 	}
 
-	identity, err := k.arnResolver.Resolve(req.Role)
+	resolvedRole, err := k.arnResolver.Resolve(req.Role)
 	if err != nil {
 		return nil, err
 	}
+
+	identity := &sts.RoleIdentity{
+		Role:        *resolvedRole,
+		SessionName: k8s.PodSessionName(pod),
+		ExternalID:  k8s.PodExternalID(pod),
+	}
+
 	creds, err := k.credentialsProvider.CredentialsForRole(ctx, identity)
 	if err != nil {
 		logger.Errorf("error retrieving credentials: %s", err.Error())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -105,15 +105,12 @@ func (k *KiamServer) GetPodCredentials(ctx context.Context, req *pb.GetPodCreden
 		return nil, ErrPolicyForbidden
 	}
 
-	resolvedRole, err := k.arnResolver.Resolve(req.Role)
+	sessionName := k8s.PodSessionName(pod)
+	externalID := k8s.PodExternalID(pod)
+
+	identity, err := sts.NewRoleIdentity(k.arnResolver, req.Role, sessionName, externalID)
 	if err != nil {
 		return nil, err
-	}
-
-	identity := &sts.RoleIdentity{
-		Role:        *resolvedRole,
-		SessionName: k8s.PodSessionName(pod),
-		ExternalID:  k8s.PodExternalID(pod),
 	}
 
 	creds, err := k.credentialsProvider.CredentialsForRole(ctx, identity)

--- a/pkg/server/server_integration_test.go
+++ b/pkg/server/server_integration_test.go
@@ -16,12 +16,14 @@ package server
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/fortytw2/leaktest"
+	"github.com/uswitch/kiam/pkg/aws/sts"
 	"github.com/uswitch/kiam/pkg/k8s"
 	"google.golang.org/grpc"
 	kt "k8s.io/client-go/tools/cache/testing"
-	"testing"
-	"time"
 )
 
 const (
@@ -120,7 +122,7 @@ func newTestServer(ctx context.Context) (*KiamServer, *kt.FakeControllerSource, 
 	source := kt.NewFakeControllerSource()
 	defer source.Shutdown()
 
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	podCache := k8s.NewPodCache(sts.DefaultResolver("arn:account:"), source, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 	namespaceCache := k8s.NewNamespaceCache(source, time.Second)
 	namespaceCache.Run(ctx)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -41,7 +41,7 @@ func TestReturnsErrorWhenPodNotFound(t *testing.T) {
 	source := kt.NewFakeControllerSource()
 	defer source.Shutdown()
 
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	podCache := k8s.NewPodCache(sts.DefaultResolver("arn:account:"), source, time.Second, defaultBuffer)
 	server := &KiamServer{pods: podCache}
 
 	_, err := server.GetPodCredentials(context.Background(), &pb.GetPodCredentialsRequest{})
@@ -61,7 +61,7 @@ func TestReturnsPolicyErrorWhenForbidden(t *testing.T) {
 	defer source.Shutdown()
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
 
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	podCache := k8s.NewPodCache(sts.DefaultResolver("arn:account:"), source, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 	server := &KiamServer{pods: podCache, assumePolicy: &forbidPolicy{}, arnResolver: sts.DefaultResolver("prefix")}
 
@@ -81,7 +81,7 @@ func TestReturnsAnnotatedPodRole(t *testing.T) {
 	defer source.Shutdown()
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
 
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	podCache := k8s.NewPodCache(sts.DefaultResolver("arn:account:"), source, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 
 	server := &KiamServer{pods: podCache, assumePolicy: &allowPolicy{}, credentialsProvider: &stubCredentialsProvider{accessKey: "A1234"}}
@@ -102,7 +102,7 @@ func TestReturnsErrorFromGetPodRoleWhenPodNotFound(t *testing.T) {
 	defer source.Shutdown()
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
 
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	podCache := k8s.NewPodCache(sts.DefaultResolver("arn:account:"), source, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 
 	server := &KiamServer{pods: podCache, assumePolicy: &allowPolicy{}, credentialsProvider: &stubCredentialsProvider{accessKey: "A1234"}}
@@ -126,7 +126,7 @@ func TestReturnsCredentials(t *testing.T) {
 	defer source.Shutdown()
 	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", roleName))
 
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	podCache := k8s.NewPodCache(sts.DefaultResolver("arn:account:"), source, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 	server := &KiamServer{pods: podCache, assumePolicy: &allowPolicy{}, credentialsProvider: &stubCredentialsProvider{accessKey: "A1234"}, arnResolver: sts.DefaultResolver("prefix")}
 
@@ -158,7 +158,7 @@ func TestGetPodCredentialsWithSessionName(t *testing.T) {
 	source.Add(testutil.NewPodWithSessionName("ns", "name", "192.168.0.1", "Running", roleName, sessionName))
 
 	credentialsProvider := stubCredentialsProvider{accessKey: "A1234"}
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	podCache := k8s.NewPodCache(sts.DefaultResolver("arn:account:"), source, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 	server := &KiamServer{pods: podCache, assumePolicy: &allowPolicy{}, credentialsProvider: &credentialsProvider, arnResolver: sts.DefaultResolver("prefix")}
 
@@ -187,7 +187,7 @@ func TestGetPodCredentialsWithExternalID(t *testing.T) {
 	source.Add(testutil.NewPodWithExternalID("ns", "name", "192.168.0.1", "Running", roleName, externalID))
 
 	credentialsProvider := stubCredentialsProvider{accessKey: "A1234"}
-	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
+	podCache := k8s.NewPodCache(sts.DefaultResolver("arn:account:"), source, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 	server := &KiamServer{pods: podCache, assumePolicy: &allowPolicy{}, credentialsProvider: &credentialsProvider, arnResolver: sts.DefaultResolver("prefix")}
 

--- a/pkg/testutil/kubernetes.go
+++ b/pkg/testutil/kubernetes.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -57,5 +57,17 @@ func NewPod(namespace, name, ip, phase string) *v1.Pod {
 func NewPodWithRole(namespace, name, ip, phase, role string) *v1.Pod {
 	pod := NewPod(namespace, name, ip, phase)
 	pod.ObjectMeta.Annotations = map[string]string{"iam.amazonaws.com/role": role}
+	return pod
+}
+
+func NewPodWithSessionName(namespace, name, ip, phase, role, sessionName string) *v1.Pod {
+	pod := NewPodWithRole(namespace, name, ip, phase, role)
+	pod.ObjectMeta.Annotations["iam.amazonaws.com/session-name"] = sessionName
+	return pod
+}
+
+func NewPodWithExternalID(namespace, name, ip, phase, role, externalID string) *v1.Pod {
+	pod := NewPodWithRole(namespace, name, ip, phase, role)
+	pod.ObjectMeta.Annotations["iam.amazonaws.com/external-id"] = externalID
 	return pod
 }

--- a/proto/service.pb.go
+++ b/proto/service.pb.go
@@ -8,14 +8,15 @@ package kiam
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
This PR adds support for overriding the assumed roles session-name by use of a pod annotation, and also adds support for using an external-id when assuming the role.

For now I chose to simply use an annotation for overriding the session name, I felt that adding templating could be a future enhancement if it is desired.

It carries on the work from https://github.com/uswitch/kiam/pull/399 and should help us finally close off https://github.com/uswitch/kiam/pull/399 and https://github.com/uswitch/kiam/issues/38