### PR TITLE
Refactoring of policy and credentials

### DIFF
--- a/pkg/aws/sts/arn_resolver.go
+++ b/pkg/aws/sts/arn_resolver.go
@@ -29,18 +29,24 @@ func DefaultResolver(prefix string) *Resolver {
 }
 
 // Resolve converts from a role string into the absolute role arn.
-func (r *Resolver) Resolve(role string) string {
+func (r *Resolver) Resolve(role string) (*RoleIdentity, error) {
 	if role == "" {
-		return ""
+		return nil, fmt.Errorf("role can't be empty")
+	}
+
+	if strings.HasPrefix(role, "arn:") {
+		return &RoleIdentity{ARN: role, Role: roleFromArn(role)}, nil
 	}
 
 	if strings.HasPrefix(role, "/") {
 		role = strings.TrimPrefix(role, "/")
 	}
 
-	if strings.HasPrefix(role, "arn:") {
-		return role
-	}
+	return &RoleIdentity{ARN: fmt.Sprintf("%s%s", r.prefix, role), Role: role}, nil
+}
 
-	return fmt.Sprintf("%s%s", r.prefix, role)
+// arn:aws:iam::account-id:role/role-name-with-path
+func roleFromArn(arn string) string {
+	splits := strings.SplitAfterN(arn, ":", 6)
+	return strings.TrimPrefix(splits[5], "role/")
 }

--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -34,12 +34,13 @@ type credentialsCache struct {
 	gateway         STSGateway
 }
 
-type CredentialsIdentity struct {
+type RoleIdentity struct {
 	Role string
+	ARN  string // Amazon Resource Name for the Role
 }
 
 type CachedCredentials struct {
-	Identity    *CredentialsIdentity
+	Identity    *RoleIdentity
 	Credentials *Credentials
 }
 
@@ -52,10 +53,8 @@ func DefaultCache(
 	sessionName string,
 	sessionDuration time.Duration,
 	sessionRefresh time.Duration,
-	resolver ARNResolver,
 ) *credentialsCache {
 	c := &credentialsCache{
-		arnResolver:     resolver,
 		expiring:        make(chan *CachedCredentials, 1),
 		sessionName:     fmt.Sprintf("kiam-%s", sessionName),
 		sessionDuration: sessionDuration,
@@ -93,8 +92,10 @@ func (c *credentialsCache) Expiring() chan *CachedCredentials {
 	return c.expiring
 }
 
-func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *CredentialsIdentity) (*Credentials, error) {
-	logger := log.WithFields(log.Fields{"pod.iam.role": identity.Role})
+// CredentialsForRole looks for cached credentials or requests them from the STSGateway. Requested credentials
+// must have their ARN set.
+func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *RoleIdentity) (*Credentials, error) {
+	logger := log.WithFields(log.Fields{"pod.iam.role": identity.Role, "pod.iam.roleArn": identity.ARN})
 	item, found := c.cache.Get(identity.String())
 
 	if found {
@@ -116,8 +117,7 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *Cre
 	cacheMiss.Inc()
 
 	issue := func() (interface{}, error) {
-		arn := c.arnResolver.Resolve(identity.Role)
-		credentials, err := c.gateway.Issue(ctx, arn, c.sessionName, c.sessionDuration)
+		credentials, err := c.gateway.Issue(ctx, identity.ARN, c.sessionName, c.sessionDuration)
 		if err != nil {
 			errorIssuing.Inc()
 			logger.Errorf("error requesting credentials: %s", err.Error())
@@ -146,6 +146,6 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *Cre
 	return cachedCreds.Credentials, nil
 }
 
-func (i *CredentialsIdentity) String() string {
-	return i.Role
+func (i *RoleIdentity) String() string {
+	return i.ARN
 }

--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -149,3 +149,7 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *Rol
 func (i *RoleIdentity) String() string {
 	return i.ARN
 }
+
+func (i *RoleIdentity) Equals(other *RoleIdentity) bool {
+	return *i == *other
+}

--- a/pkg/aws/sts/credentials_cache_test.go
+++ b/pkg/aws/sts/credentials_cache_test.go
@@ -34,10 +34,11 @@ func (s *stubGateway) Issue(ctx context.Context, roleARN, sessionName string, ex
 
 func TestRequestsCredentialsFromGatewayWithEmptyCache(t *testing.T) {
 	stubGateway := &stubGateway{c: &Credentials{Code: "foo"}}
-	cache := DefaultCache(stubGateway, "session", 15*time.Minute, 5*time.Minute, DefaultResolver("prefix:"))
+	cache := DefaultCache(stubGateway, "session", 15*time.Minute, 5*time.Minute)
 	ctx := context.Background()
 
-	creds, _ := cache.CredentialsForRole(ctx, &CredentialsIdentity{Role: "role"})
+	credentialsIdentity := &RoleIdentity{Role: "role", ARN: "arn:account:role"}
+	creds, _ := cache.CredentialsForRole(ctx, credentialsIdentity)
 	if creds.Code != "foo" {
 		t.Error("didnt return expected credentials code, was", creds.Code)
 	}
@@ -45,12 +46,12 @@ func TestRequestsCredentialsFromGatewayWithEmptyCache(t *testing.T) {
 		t.Error("expected to cache credential, was", testutil.ToFloat64(cacheSize))
 	}
 
-	cache.CredentialsForRole(ctx, &CredentialsIdentity{Role: "role"})
+	cache.CredentialsForRole(ctx, credentialsIdentity)
 	if stubGateway.issueCount != 1 {
 		t.Error("expected creds to be cached")
 	}
 
-	if stubGateway.requestedRole != "prefix:role" {
+	if stubGateway.requestedRole != "arn:account:role" {
 		t.Error("unexpected role, was:", stubGateway.requestedRole)
 	}
 }

--- a/pkg/aws/sts/interfaces.go
+++ b/pkg/aws/sts/interfaces.go
@@ -28,5 +28,5 @@ type CredentialsCache interface {
 
 // ARNResolver encapsulates resolution of roles into ARNs.
 type ARNResolver interface {
-	Resolve(role string) string
+	Resolve(role string) (*RoleIdentity, error)
 }

--- a/pkg/aws/sts/interfaces.go
+++ b/pkg/aws/sts/interfaces.go
@@ -18,11 +18,11 @@ import (
 )
 
 type CredentialsProvider interface {
-	CredentialsForRole(ctx context.Context, identity *CredentialsIdentity) (*Credentials, error)
+	CredentialsForRole(ctx context.Context, identity *RoleIdentity) (*Credentials, error)
 }
 
 type CredentialsCache interface {
-	CredentialsForRole(ctx context.Context, identity *CredentialsIdentity) (*Credentials, error)
+	CredentialsForRole(ctx context.Context, identity *RoleIdentity) (*Credentials, error)
 	Expiring() chan *CachedCredentials
 }
 

--- a/pkg/aws/sts/log.go
+++ b/pkg/aws/sts/log.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func CredentialsFields(identity *CredentialsIdentity, creds *Credentials) log.Fields {
+func CredentialsFields(identity *RoleIdentity, creds *Credentials) log.Fields {
 	return log.Fields{
 		"credentials.access.key": creds.AccessKeyId,
 		"credentials.expiration": creds.Expiration,

--- a/pkg/prefetch/manager.go
+++ b/pkg/prefetch/manager.go
@@ -43,7 +43,10 @@ func (m *CredentialManager) fetchCredentials(ctx context.Context, pod *v1.Pod) {
 	}
 
 	role := k8s.PodRole(pod)
-	identity := &sts.RoleIdentity{Role: role, ARN: m.arnResolver.Resolve(role)}
+	identity, err := m.arnResolver.Resolve(role)
+	if err != nil {
+		return
+	}
 	issued, err := m.fetchCredentialsFromCache(ctx, identity)
 	if err != nil {
 		logger.Errorf("error warming credentials: %s", err.Error())

--- a/pkg/prefetch/manager.go
+++ b/pkg/prefetch/manager.go
@@ -22,13 +22,17 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+// CredentialManager watches for Pod changes and prefetches credentials. For any
+// expiring credentials it checks whether pods are still active and requests new
+// ones.
 type CredentialManager struct {
-	cache     sts.CredentialsCache
-	announcer k8s.PodAnnouncer
+	cache       sts.CredentialsCache // where it stores credentials
+	announcer   k8s.PodAnnouncer     // to understand which pods are running
+	arnResolver sts.ARNResolver      // to convert from role names to fully qualified names
 }
 
-func NewManager(cache sts.CredentialsCache, announcer k8s.PodAnnouncer) *CredentialManager {
-	return &CredentialManager{cache: cache, announcer: announcer}
+func NewManager(cache sts.CredentialsCache, announcer k8s.PodAnnouncer, resolver sts.ARNResolver) *CredentialManager {
+	return &CredentialManager{cache: cache, announcer: announcer, arnResolver: resolver}
 }
 
 func (m *CredentialManager) fetchCredentials(ctx context.Context, pod *v1.Pod) {
@@ -39,7 +43,7 @@ func (m *CredentialManager) fetchCredentials(ctx context.Context, pod *v1.Pod) {
 	}
 
 	role := k8s.PodRole(pod)
-	identity := &sts.CredentialsIdentity{Role: role}
+	identity := &sts.RoleIdentity{Role: role, ARN: m.arnResolver.Resolve(role)}
 	issued, err := m.fetchCredentialsFromCache(ctx, identity)
 	if err != nil {
 		logger.Errorf("error warming credentials: %s", err.Error())
@@ -48,7 +52,7 @@ func (m *CredentialManager) fetchCredentials(ctx context.Context, pod *v1.Pod) {
 	}
 }
 
-func (m *CredentialManager) fetchCredentialsFromCache(ctx context.Context, identity *sts.CredentialsIdentity) (*sts.Credentials, error) {
+func (m *CredentialManager) fetchCredentialsFromCache(ctx context.Context, identity *sts.RoleIdentity) (*sts.Credentials, error) {
 	return m.cache.CredentialsForRole(ctx, identity)
 }
 

--- a/pkg/prefetch/manager_test.go
+++ b/pkg/prefetch/manager_test.go
@@ -32,11 +32,11 @@ func TestPrefetchRunningPods(t *testing.T) {
 
 	requestedRoles := make(chan string)
 	announcer := kt.NewStubAnnouncer()
-	cache := testutil.NewStubCredentialsCache(func(identity *sts.CredentialsIdentity) (*sts.Credentials, error) {
+	cache := testutil.NewStubCredentialsCache(func(identity *sts.RoleIdentity) (*sts.Credentials, error) {
 		requestedRoles <- identity.Role
 		return &sts.Credentials{}, nil
 	})
-	manager := NewManager(cache, announcer)
+	manager := NewManager(cache, announcer, sts.DefaultResolver("prefix"))
 	go manager.Run(ctx, 1)
 
 	announcer.Announce(testutil.NewPodWithRole("ns", "name", "ip", "Running", "role"))

--- a/pkg/server/policy.go
+++ b/pkg/server/policy.go
@@ -17,32 +17,17 @@ package server
 import (
 	"context"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"regexp"
 
 	"github.com/uswitch/kiam/pkg/aws/sts"
 	"github.com/uswitch/kiam/pkg/k8s"
 )
 
-// Decision reports (with message) as to whether the assume role is permitted.
-type Decision interface {
-	IsAllowed() bool
-	Explanation() string
-}
-
-type allowed struct {
-}
-
-func (a *allowed) IsAllowed() bool {
-	return true
-}
-func (a *allowed) Explanation() string {
-	return ""
-}
-
 // AssumeRolePolicy allows for policy to check whether pods can assume the role being
 // requested
 type AssumeRolePolicy interface {
-	IsAllowedAssumeRole(ctx context.Context, roleName, podIP string) (Decision, error)
+	IsAllowedAssumeRole(ctx context.Context, roleName string, pod *v1.Pod) (Decision, error)
 }
 
 // CompositeAssumeRolePolicy allows multiple policies to be checked
@@ -50,9 +35,9 @@ type CompositeAssumeRolePolicy struct {
 	policies []AssumeRolePolicy
 }
 
-func (p *CompositeAssumeRolePolicy) IsAllowedAssumeRole(ctx context.Context, role, podIP string) (Decision, error) {
+func (p *CompositeAssumeRolePolicy) IsAllowedAssumeRole(ctx context.Context, role string, pod *v1.Pod) (Decision, error) {
 	for _, policy := range p.policies {
-		decision, err := policy.IsAllowedAssumeRole(ctx, role, podIP)
+		decision, err := policy.IsAllowedAssumeRole(ctx, role, pod)
 		if err != nil {
 			return nil, err
 		}
@@ -82,24 +67,7 @@ func NewRequestingAnnotatedRolePolicy(p k8s.PodGetter, resolver sts.ARNResolver)
 	return &RequestingAnnotatedRolePolicy{pods: p, resolver: resolver}
 }
 
-type forbidden struct {
-	requested string
-	annotated string
-}
-
-func (f *forbidden) IsAllowed() bool {
-	return false
-}
-func (f *forbidden) Explanation() string {
-	return fmt.Sprintf("requested '%s' but annotated with '%s', forbidden", f.requested, f.annotated)
-}
-
-func (p *RequestingAnnotatedRolePolicy) IsAllowedAssumeRole(ctx context.Context, role, podIP string) (Decision, error) {
-	pod, err := p.pods.GetPodByIP(podIP)
-	if err != nil {
-		return nil, err
-	}
-
+func (p *RequestingAnnotatedRolePolicy) IsAllowedAssumeRole(ctx context.Context, role string, pod *v1.Pod) (Decision, error) {
 	annotatedRole := p.resolver.Resolve(k8s.PodRole(pod))
 	role = p.resolver.Resolve(role)
 
@@ -112,35 +80,15 @@ func (p *RequestingAnnotatedRolePolicy) IsAllowedAssumeRole(ctx context.Context,
 
 type NamespacePermittedRoleNamePolicy struct {
 	namespaces k8s.NamespaceFinder
-	pods       k8s.PodGetter
 	resolver   sts.ARNResolver
 }
 
-func NewNamespacePermittedRoleNamePolicy(n k8s.NamespaceFinder, p k8s.PodGetter, resolver sts.ARNResolver) *NamespacePermittedRoleNamePolicy {
-	return &NamespacePermittedRoleNamePolicy{namespaces: n, pods: p, resolver: resolver}
+func NewNamespacePermittedRoleNamePolicy(n k8s.NamespaceFinder, resolver sts.ARNResolver) *NamespacePermittedRoleNamePolicy {
+	return &NamespacePermittedRoleNamePolicy{namespaces: n, resolver: resolver}
 }
 
-type namespacePolicyForbidden struct {
-	expression string
-	role       string
-}
-
-func (f *namespacePolicyForbidden) IsAllowed() bool {
-	return false
-}
-
-func (f *namespacePolicyForbidden) Explanation() string {
-	return fmt.Sprintf("namespace policy expression '%s' forbids role '%s'", f.expression, f.role)
-}
-
-func (p *NamespacePermittedRoleNamePolicy) IsAllowedAssumeRole(ctx context.Context, role, podIP string) (Decision, error) {
-
+func (p *NamespacePermittedRoleNamePolicy) IsAllowedAssumeRole(ctx context.Context, role string, pod *v1.Pod) (Decision, error) {
 	role = p.resolver.Resolve(role)
-
-	pod, err := p.pods.GetPodByIP(podIP)
-	if err != nil {
-		return nil, err
-	}
 
 	ns, err := p.namespaces.FindNamespace(ctx, pod.GetObjectMeta().GetNamespace())
 	if err != nil {
@@ -162,4 +110,46 @@ func (p *NamespacePermittedRoleNamePolicy) IsAllowedAssumeRole(ctx context.Conte
 	}
 
 	return &allowed{}, nil
+}
+
+// Decision reports (with message) as to whether the assume role is permitted.
+type Decision interface {
+	IsAllowed() bool
+	Explanation() string
+}
+
+type allowed struct {
+}
+
+func (a *allowed) IsAllowed() bool {
+	return true
+}
+
+func (a *allowed) Explanation() string {
+	return ""
+}
+
+type forbidden struct {
+	requested string
+	annotated string
+}
+
+func (f *forbidden) IsAllowed() bool {
+	return false
+}
+func (f *forbidden) Explanation() string {
+	return fmt.Sprintf("requested '%s' but annotated with '%s', forbidden", f.requested, f.annotated)
+}
+
+type namespacePolicyForbidden struct {
+	expression string
+	role       string
+}
+
+func (f *namespacePolicyForbidden) IsAllowed() bool {
+	return false
+}
+
+func (f *namespacePolicyForbidden) Explanation() string {
+	return fmt.Sprintf("namespace policy expression '%s' forbids role '%s'", f.expression, f.role)
 }

--- a/pkg/server/policy_test.go
+++ b/pkg/server/policy_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/uswitch/kiam/pkg/aws/sts"
-	"github.com/uswitch/kiam/pkg/k8s"
 	kt "github.com/uswitch/kiam/pkg/k8s/testing"
 	"github.com/uswitch/kiam/pkg/testutil"
 )
@@ -29,7 +28,7 @@ func TestRequestedRolePolicy(t *testing.T) {
 
 	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
 	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
-	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -39,7 +38,7 @@ func TestRequestedRolePolicy(t *testing.T) {
 	}
 
 	policy = NewRequestingAnnotatedRolePolicy(f, arnResolver)
-	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -48,12 +47,12 @@ func TestRequestedRolePolicy(t *testing.T) {
 		t.Error("role was same, should have been permitted:", decision.Explanation())
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", p)
 	if decision.IsAllowed() {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", p)
 	if decision.IsAllowed() {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
@@ -65,7 +64,7 @@ func TestRequestedRolePolicyWithSlash(t *testing.T) {
 	f := kt.NewStubFinder(p)
 
 	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
-	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -75,7 +74,7 @@ func TestRequestedRolePolicyWithSlash(t *testing.T) {
 	}
 
 	policy = NewRequestingAnnotatedRolePolicy(f, arnResolver)
-	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -84,51 +83,25 @@ func TestRequestedRolePolicyWithSlash(t *testing.T) {
 		t.Error("role was same, should have been permitted:", decision.Explanation())
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", p)
 	if decision.IsAllowed() {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", p)
 	if decision.IsAllowed() {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
-}
-
-func TestErrorWhenPodNotFound(t *testing.T) {
-	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
-	f := kt.NewStubFinder(nil)
-	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
-
-	_, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
-	if err == nil {
-		t.Error("no pod found, should have been error")
-	}
-
-	if err != k8s.ErrPodNotFound {
-		t.Error("wrong message", err.Error())
-	}
-
-	_, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
-	if err == nil {
-		t.Error("no pod found, should have been error")
-	}
-
-	if err != k8s.ErrPodNotFound {
-		t.Error("wrong message", err.Error())
-	}
-
 }
 
 func TestNamespacePolicy(t *testing.T) {
 	n := testutil.NewNamespace("red", "^red.*$|^.red.*$")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, err := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -137,8 +110,8 @@ func TestNamespacePolicy(t *testing.T) {
 		t.Errorf("expected to be allowed- pod in correct namespace")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -147,12 +120,12 @@ func TestNamespacePolicy(t *testing.T) {
 		t.Errorf("expected to be allowed- pod in correct namespace")
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", p)
 	if decision.IsAllowed() {
 		t.Errorf("expected to be forbidden- requesting role that fails regexp")
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", p)
 	if decision.IsAllowed() {
 		t.Errorf("expected to be forbidden- requesting role that fails regexp")
 	}
@@ -162,11 +135,10 @@ func TestNamespacePolicyWithSlash(t *testing.T) {
 	n := testutil.NewNamespace("red", "^red.*$|^.red.*$")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, err := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -175,8 +147,8 @@ func TestNamespacePolicyWithSlash(t *testing.T) {
 		t.Errorf("expected to be allowed- pod in correct namespace: %s", decision.Explanation())
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -185,12 +157,12 @@ func TestNamespacePolicyWithSlash(t *testing.T) {
 		t.Errorf("expected to be allowed- pod in correct namespace: %s", decision.Explanation())
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", p)
 	if decision.IsAllowed() {
 		t.Errorf("expected to be forbidden- requesting role that fails regexp")
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", p)
 	if decision.IsAllowed() {
 		t.Errorf("expected to be forbidden- requesting role that fails regexp")
 	}
@@ -200,18 +172,17 @@ func TestNotAllowedWithoutNamespaceAnnotation(t *testing.T) {
 	n := testutil.NewNamespace("red", "")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected failure, empty namespace policy annotation")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected failure, empty namespace policy annotation")
@@ -222,18 +193,17 @@ func TestNotAllowedWithoutNamespaceAnnotationWithSlash(t *testing.T) {
 	n := testutil.NewNamespace("red", "")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected failure, empty namespace policy annotation")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected failure, empty namespace policy annotation")
@@ -244,18 +214,17 @@ func TestAllowedWithARNResolverBaseRole(t *testing.T) {
 	n := testutil.NewNamespace("red", "arn:aws:iam::123456789012:role/.*")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if !decision.IsAllowed() {
 		t.Errorf("expected to be allowed- namespace base role regex match resolver base role: %s", decision.Explanation())
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if !decision.IsAllowed() {
 		t.Errorf("expected to be allowed- namespace base role regex match resolver base role: %s", decision.Explanation())
@@ -266,18 +235,17 @@ func TestNotAllowedWithoutARNResolverBaseRole(t *testing.T) {
 	n := testutil.NewNamespace("red", "arn:aws:iam::123456789012:role/*")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected to be forbidden- requesting role that fails base role regexp")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected to be forbidden- requesting role that fails base role regexp")
@@ -288,18 +256,17 @@ func TestAllowedWithSubPathRegexInNamespace(t *testing.T) {
 	n := testutil.NewNamespace("red", ".*/subpath/.*")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("arn:aws:iam::account-id:role/subpath/")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if !decision.IsAllowed() {
 		t.Error("expected to be allowed- namespace regex matches role subpath", decision.Explanation())
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if !decision.IsAllowed() {
 		t.Error("expected to be allowed- namespace regex matches role subpath", decision.Explanation())
@@ -310,18 +277,17 @@ func TestNotAllowedWithoutSubPathRegexInNamespace(t *testing.T) {
 	n := testutil.NewNamespace("red", "arn:aws:iam::account-id:role/red.*")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("arn:aws:iam::account-id:role/subpath/")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected to be forbidden- namespace regex DOES NOT match role subpath")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected to be forbidden- namespace regex DOES NOT match role subpath")
@@ -332,18 +298,17 @@ func TestAllowedWithExactSubPathInNamespace(t *testing.T) {
 	n := testutil.NewNamespace("red", "arn:aws:iam::account-id:role/subpath/red_role")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("arn:aws:iam::account-id:role/subpath/")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if !decision.IsAllowed() {
 		t.Error("expected to be allowed- namespace matches role subpath", decision.Explanation())
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if !decision.IsAllowed() {
 		t.Error("expected to be allowed- namespace matches role subpath", decision.Explanation())
@@ -354,18 +319,17 @@ func TestNotAllowedWithoutExactSubPathInNamespace(t *testing.T) {
 	n := testutil.NewNamespace("red", "arn:aws:iam::account-id:role/subpath/blue_role")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
-	pf := kt.NewStubFinder(p)
 	arnResolver := sts.DefaultResolver("arn:aws:iam::account-id:role/subpath/")
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected to be forbidden- namespace role DOES NOT match role subpath")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf, arnResolver)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf, arnResolver)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected to be forbidden- namespace role DOES NOT match role subpath")

--- a/pkg/server/policy_test.go
+++ b/pkg/server/policy_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/uswitch/kiam/pkg/aws/sts"
-	"github.com/uswitch/kiam/pkg/k8s"
 	kt "github.com/uswitch/kiam/pkg/k8s/testing"
 	"github.com/uswitch/kiam/pkg/testutil"
 )
@@ -29,7 +28,7 @@ func TestRequestedRolePolicy(t *testing.T) {
 
 	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
 	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
-	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -39,7 +38,7 @@ func TestRequestedRolePolicy(t *testing.T) {
 	}
 
 	policy = NewRequestingAnnotatedRolePolicy(f, arnResolver)
-	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -48,12 +47,12 @@ func TestRequestedRolePolicy(t *testing.T) {
 		t.Error("role was same, should have been permitted:", decision.Explanation())
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", p)
 	if decision.IsAllowed() {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", p)
 	if decision.IsAllowed() {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
@@ -65,7 +64,7 @@ func TestRequestedRolePolicyWithSlash(t *testing.T) {
 	f := kt.NewStubFinder(p)
 
 	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
-	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -75,7 +74,7 @@ func TestRequestedRolePolicyWithSlash(t *testing.T) {
 	}
 
 	policy = NewRequestingAnnotatedRolePolicy(f, arnResolver)
-	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -84,50 +83,24 @@ func TestRequestedRolePolicyWithSlash(t *testing.T) {
 		t.Error("role was same, should have been permitted:", decision.Explanation())
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "wrongrole", p)
 	if decision.IsAllowed() {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/wrongrole", p)
 	if decision.IsAllowed() {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
-}
-
-func TestErrorWhenPodNotFound(t *testing.T) {
-	arnResolver := sts.DefaultResolver("arn:aws:iam::123456789012:role/")
-	f := kt.NewStubFinder(nil)
-	policy := NewRequestingAnnotatedRolePolicy(f, arnResolver)
-
-	_, err := policy.IsAllowedAssumeRole(context.Background(), "myrole", "192.168.0.1")
-	if err == nil {
-		t.Error("no pod found, should have been error")
-	}
-
-	if err != k8s.ErrPodNotFound {
-		t.Error("wrong message", err.Error())
-	}
-
-	_, err = policy.IsAllowedAssumeRole(context.Background(), "/myrole", "192.168.0.1")
-	if err == nil {
-		t.Error("no pod found, should have been error")
-	}
-
-	if err != k8s.ErrPodNotFound {
-		t.Error("wrong message", err.Error())
-	}
-
 }
 
 func TestNamespacePolicy(t *testing.T) {
 	n := testutil.NewNamespace("red", "^red.*$|^.red.*$")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
-	pf := kt.NewStubFinder(p)
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf)
-	decision, err := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf)
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -136,8 +109,8 @@ func TestNamespacePolicy(t *testing.T) {
 		t.Errorf("expected to be allowed- pod in correct namespace")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf)
-	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf)
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -146,12 +119,12 @@ func TestNamespacePolicy(t *testing.T) {
 		t.Errorf("expected to be allowed- pod in correct namespace")
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", p)
 	if decision.IsAllowed() {
 		t.Errorf("expected to be forbidden- requesting role that fails regexp")
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", p)
 	if decision.IsAllowed() {
 		t.Errorf("expected to be forbidden- requesting role that fails regexp")
 	}
@@ -161,10 +134,9 @@ func TestNamespacePolicyWithSlash(t *testing.T) {
 	n := testutil.NewNamespace("red", "^red.*$|^.red.*$")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
-	pf := kt.NewStubFinder(p)
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf)
-	decision, err := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf)
+	decision, err := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -173,8 +145,8 @@ func TestNamespacePolicyWithSlash(t *testing.T) {
 		t.Errorf("expected to be allowed- pod in correct namespace")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf)
-	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf)
+	decision, err = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -183,12 +155,12 @@ func TestNamespacePolicyWithSlash(t *testing.T) {
 		t.Errorf("expected to be allowed- pod in correct namespace")
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "orange_role", p)
 	if decision.IsAllowed() {
 		t.Errorf("expected to be forbidden- requesting role that fails regexp")
 	}
 
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", "192.168.0.1")
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/orange_role", p)
 	if decision.IsAllowed() {
 		t.Errorf("expected to be forbidden- requesting role that fails regexp")
 	}
@@ -198,17 +170,16 @@ func TestNotAllowedWithoutNamespaceAnnotation(t *testing.T) {
 	n := testutil.NewNamespace("red", "")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "red_role")
-	pf := kt.NewStubFinder(p)
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected failure, empty namespace policy annotation")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected failure, empty namespace policy annotation")
@@ -219,17 +190,16 @@ func TestNotAllowedWithoutNamespaceAnnotationWithSlash(t *testing.T) {
 	n := testutil.NewNamespace("red", "")
 	nf := kt.NewNamespaceFinder(n)
 	p := testutil.NewPodWithRole("red", "foo", "192.168.0.1", testutil.PhaseRunning, "/red_role")
-	pf := kt.NewStubFinder(p)
 
-	policy := NewNamespacePermittedRoleNamePolicy(nf, pf)
-	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", "192.168.0.1")
+	policy := NewNamespacePermittedRoleNamePolicy(nf)
+	decision, _ := policy.IsAllowedAssumeRole(context.Background(), "red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected failure, empty namespace policy annotation")
 	}
 
-	policy = NewNamespacePermittedRoleNamePolicy(nf, pf)
-	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", "192.168.0.1")
+	policy = NewNamespacePermittedRoleNamePolicy(nf)
+	decision, _ = policy.IsAllowedAssumeRole(context.Background(), "/red_role", p)
 
 	if decision.IsAllowed() {
 		t.Error("expected failure, empty namespace policy annotation")

--- a/pkg/server/policy_test.go
+++ b/pkg/server/policy_test.go
@@ -62,7 +62,7 @@ func TestRequestedRolePolicy(t *testing.T) {
 		t.Error("role is different, should be denied", decision.Explanation())
 	}
 
-	if decision.Explanation() != "requested 'arn:aws:iam::123456789012:role/wrongrole' but annotated with 'arn:aws:iam::123456789012:role/myrole', forbidden" {
+	if decision.Explanation() != "requested 'wrongrole' but annotated with 'myrole', forbidden" {
 		t.Error("unexpected explanation, was", decision.Explanation())
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -105,7 +105,11 @@ func (k *KiamServer) GetPodCredentials(ctx context.Context, req *pb.GetPodCreden
 		return nil, ErrPolicyForbidden
 	}
 
-	creds, err := k.credentialsProvider.CredentialsForRole(ctx, &sts.RoleIdentity{Role: req.Role, ARN: k.arnResolver.Resolve(req.Role)})
+	identity, err := k.arnResolver.Resolve(req.Role)
+	if err != nil {
+		return nil, err
+	}
+	creds, err := k.credentialsProvider.CredentialsForRole(ctx, identity)
 	if err != nil {
 		logger.Errorf("error retrieving credentials: %s", err.Error())
 		k.recordEvent(pod, v1.EventTypeWarning, "KiamCredentialError", fmt.Sprintf("failed retrieving credentials: %s", simplifyAWSErrorMessage(err)))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -68,6 +68,7 @@ type KiamServer struct {
 	credentialsProvider sts.CredentialsProvider
 	assumePolicy        AssumeRolePolicy
 	parallelFetchers    int
+	arnResolver         sts.ARNResolver
 }
 
 func simplifyAWSErrorMessage(err error) string {
@@ -92,7 +93,7 @@ func (k *KiamServer) GetPodCredentials(ctx context.Context, req *pb.GetPodCreden
 	}
 	logger := log.WithFields(k8s.PodFields(pod)).WithField("pod.iam.requestedRole", req.Role)
 
-	decision, err := k.assumePolicy.IsAllowedAssumeRole(ctx, req.Role, req.Ip)
+	decision, err := k.assumePolicy.IsAllowedAssumeRole(ctx, req.Role, pod)
 	if err != nil {
 		logger.Errorf("error checking policy: %s", err.Error())
 		return nil, err
@@ -104,7 +105,7 @@ func (k *KiamServer) GetPodCredentials(ctx context.Context, req *pb.GetPodCreden
 		return nil, ErrPolicyForbidden
 	}
 
-	creds, err := k.credentialsProvider.CredentialsForRole(ctx, &sts.CredentialsIdentity{Role: req.Role})
+	creds, err := k.credentialsProvider.CredentialsForRole(ctx, &sts.RoleIdentity{Role: req.Role, ARN: k.arnResolver.Resolve(req.Role)})
 	if err != nil {
 		logger.Errorf("error retrieving credentials: %s", err.Error())
 		k.recordEvent(pod, v1.EventTypeWarning, "KiamCredentialError", fmt.Sprintf("failed retrieving credentials: %s", simplifyAWSErrorMessage(err)))

--- a/pkg/server/server_builder.go
+++ b/pkg/server/server_builder.go
@@ -203,7 +203,7 @@ func (b *KiamServerBuilder) Build() (*KiamServer, error) {
 		credentialsProvider: credentialsCache,
 		assumePolicy: Policies(
 			NewRequestingAnnotatedRolePolicy(b.podCache, arnResolver),
-			NewNamespacePermittedRoleNamePolicy(b.namespaceCache),
+			NewNamespacePermittedRoleNamePolicy(b.namespaceCache, arnResolver),
 		),
 		parallelFetchers: b.config.ParallelFetcherProcesses,
 	}

--- a/pkg/server/server_builder.go
+++ b/pkg/server/server_builder.go
@@ -185,7 +185,6 @@ func (b *KiamServerBuilder) Build() (*KiamServer, error) {
 		b.config.SessionName,
 		b.config.SessionDuration,
 		b.config.SessionRefresh,
-		arnResolver,
 	)
 
 	listener, err := net.Listen("tcp", b.config.BindAddress)
@@ -200,11 +199,11 @@ func (b *KiamServerBuilder) Build() (*KiamServer, error) {
 		pods:                b.podCache,
 		namespaces:          b.namespaceCache,
 		eventRecorder:       b.eventRecorder,
-		manager:             prefetch.NewManager(credentialsCache, b.podCache),
+		manager:             prefetch.NewManager(credentialsCache, b.podCache, arnResolver),
 		credentialsProvider: credentialsCache,
 		assumePolicy: Policies(
 			NewRequestingAnnotatedRolePolicy(b.podCache, arnResolver),
-			NewNamespacePermittedRoleNamePolicy(b.namespaceCache, b.podCache),
+			NewNamespacePermittedRoleNamePolicy(b.namespaceCache),
 		),
 		parallelFetchers: b.config.ParallelFetcherProcesses,
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -119,15 +119,17 @@ func TestReturnsCredentials(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	const roleName = "running_role"
+
 	source := kt.NewFakeControllerSource()
 	defer source.Shutdown()
-	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", "running_role"))
+	source.Add(testutil.NewPodWithRole("ns", "name", "192.168.0.1", "Running", roleName))
 
 	podCache := k8s.NewPodCache(source, time.Second, defaultBuffer)
 	podCache.Run(ctx)
 	server := &KiamServer{pods: podCache, assumePolicy: &allowPolicy{}, credentialsProvider: &stubCredentialsProvider{accessKey: "A1234"}, arnResolver: sts.DefaultResolver("prefix")}
 
-	creds, err := server.GetPodCredentials(ctx, &pb.GetPodCredentialsRequest{Ip: "192.168.0.1"})
+	creds, err := server.GetPodCredentials(ctx, &pb.GetPodCredentialsRequest{Ip: "192.168.0.1", Role: roleName})
 	if err != nil {
 		t.Error("unexpected error", err)
 	}

--- a/pkg/testutil/issuer.go
+++ b/pkg/testutil/issuer.go
@@ -20,7 +20,8 @@ import (
 )
 
 type stubCache struct {
-	issue func(identity *sts.RoleIdentity) (*sts.Credentials, error)
+	expiring chan *sts.CachedCredentials
+	issue    func(identity *sts.RoleIdentity) (*sts.Credentials, error)
 }
 
 func (i *stubCache) CredentialsForRole(ctx context.Context, identity *sts.RoleIdentity) (*sts.Credentials, error) {
@@ -28,9 +29,13 @@ func (i *stubCache) CredentialsForRole(ctx context.Context, identity *sts.RoleId
 }
 
 func (i *stubCache) Expiring() chan *sts.CachedCredentials {
-	return make(chan *sts.CachedCredentials)
+	return i.expiring
 }
 
-func NewStubCredentialsCache(f func(identity *sts.RoleIdentity) (*sts.Credentials, error)) sts.CredentialsCache {
-	return &stubCache{f}
+func (i *stubCache) Expire(credentials *sts.CachedCredentials) {
+	i.expiring <- credentials
+}
+
+func NewStubCredentialsCache(issueFunc func(identity *sts.RoleIdentity) (*sts.Credentials, error)) *stubCache {
+	return &stubCache{issue: issueFunc, expiring: make(chan *sts.CachedCredentials)}
 }

--- a/pkg/testutil/issuer.go
+++ b/pkg/testutil/issuer.go
@@ -20,10 +20,10 @@ import (
 )
 
 type stubCache struct {
-	issue func(identity *sts.CredentialsIdentity) (*sts.Credentials, error)
+	issue func(identity *sts.RoleIdentity) (*sts.Credentials, error)
 }
 
-func (i *stubCache) CredentialsForRole(ctx context.Context, identity *sts.CredentialsIdentity) (*sts.Credentials, error) {
+func (i *stubCache) CredentialsForRole(ctx context.Context, identity *sts.RoleIdentity) (*sts.Credentials, error) {
 	return i.issue(identity)
 }
 
@@ -31,6 +31,6 @@ func (i *stubCache) Expiring() chan *sts.CachedCredentials {
 	return make(chan *sts.CachedCredentials)
 }
 
-func NewStubCredentialsCache(f func(identity *sts.CredentialsIdentity) (*sts.Credentials, error)) sts.CredentialsCache {
+func NewStubCredentialsCache(f func(identity *sts.RoleIdentity) (*sts.Credentials, error)) sts.CredentialsCache {
 	return &stubCache{f}
 }


### PR DESCRIPTION
* Rename CredentialsIdentity to RoleIdentity
* Remove arnResolver use within the credentials cache (it can work on the basis all credentials it's being used to manage have already got ARNs resolved)
* Policy interface changed to take role string and *Pod to avoid needing a PodGetter interface

@stefansedich hope you're ok with the rename of Credentials to Role? My reasoning was that the identity is largely used to refer to the role and not always when we have credentials.