### PR TITLE
Replace -ms suffix from the gRPC keepalive flags to -duration

### DIFF
--- a/cmd/kiam/opts.go
+++ b/cmd/kiam/opts.go
@@ -96,8 +96,8 @@ type clientOptions struct {
 }
 
 func (o *clientOptions) bind(parser parser) {
-	parser.Flag("grpc-keepalive-time", "gRPC keepalive time").Default("10s").DurationVar(&o.keepaliveParams.Time)
-	parser.Flag("grpc-keepalive-timeout", "gRPC keepalive timeout").Default("2s").DurationVar(&o.keepaliveParams.Timeout)
+	parser.Flag("grpc-keepalive-time-duration", "gRPC keepalive time").Default("10s").DurationVar(&o.keepaliveParams.Time)
+	parser.Flag("grpc-keepalive-timeout-duration", "gRPC keepalive timeout").Default("2s").DurationVar(&o.keepaliveParams.Timeout)
 	parser.Flag("grpc-keepalive-permit-without-stream", "gRPC keepalive ping even with no RPC").BoolVar(&o.keepaliveParams.PermitWithoutStream)
 	parser.Flag("server-address", "gRPC address to Kiam server service").Default("localhost:9610").StringVar(&o.serverAddress)
 	parser.Flag("server-address-refresh", "Interval to refresh server service endpoints ( deprecated )").Default("0s").DurationVar(&o.serverAddressRefresh)

--- a/cmd/kiam/opts.go
+++ b/cmd/kiam/opts.go
@@ -15,11 +15,12 @@ package main
 
 import (
 	"context"
+	"time"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/uswitch/kiam/pkg/pprof"
 	"github.com/uswitch/kiam/pkg/prometheus"
 	"google.golang.org/grpc/keepalive"
-	"time"
 )
 
 type logOptions struct {
@@ -95,8 +96,8 @@ type clientOptions struct {
 }
 
 func (o *clientOptions) bind(parser parser) {
-	parser.Flag("grpc-keepalive-time-ms", "gRPC keepalive time").Default("10s").DurationVar(&o.keepaliveParams.Time)
-	parser.Flag("grpc-keepalive-timeout-ms", "gRPC keepalive timeout").Default("2s").DurationVar(&o.keepaliveParams.Timeout)
+	parser.Flag("grpc-keepalive-time", "gRPC keepalive time").Default("10s").DurationVar(&o.keepaliveParams.Time)
+	parser.Flag("grpc-keepalive-timeout", "gRPC keepalive timeout").Default("2s").DurationVar(&o.keepaliveParams.Timeout)
 	parser.Flag("grpc-keepalive-permit-without-stream", "gRPC keepalive ping even with no RPC").BoolVar(&o.keepaliveParams.PermitWithoutStream)
 	parser.Flag("server-address", "gRPC address to Kiam server service").Default("localhost:9610").StringVar(&o.serverAddress)
 	parser.Flag("server-address-refresh", "Interval to refresh server service endpoints ( deprecated )").Default("0s").DurationVar(&o.serverAddressRefresh)


### PR DESCRIPTION
Replace the `-ms` suffix from the keepalive flags to `-duration` remove confusion, this is a breaking change however as discussed with @pingles the 4.0 release includes other breaking changes so the time is right.

This will also require changes to the Helm chart, these will come post release to include any changes needed to the chart for 4.0 compatibility.

Closes #354