### PR TITLE
Add support for configuring gRPC max-connection-age for the kiam server

### DIFF
--- a/cmd/kiam/server.go
+++ b/cmd/kiam/server.go
@@ -15,6 +15,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"os"
 	"os/signal"
 	"syscall"
@@ -46,6 +48,8 @@ type serverOptions struct {
 }
 
 func (o *serverOptions) bind(parser parser) {
+	infiniteDuration := fmt.Sprintf("%ds", math.MaxInt64/1000000000)
+
 	parser.Flag("fetchers", "Number of parallel fetcher go routines").Default("8").IntVar(&o.ParallelFetcherProcesses)
 	parser.Flag("prefetch-buffer-size", "How many Pod events to hold in memory between the Pod watcher and Prefetch manager.").Default("1000").IntVar(&o.PrefetchBufferSize)
 	parser.Flag("bind", "gRPC bind address").Default("localhost:9610").StringVar(&o.BindAddress)
@@ -59,6 +63,9 @@ func (o *serverOptions) bind(parser parser) {
 	parser.Flag("session-refresh", "How soon STS Tokens should be refreshed before their expiration.").Default("5m").DurationVar(&o.SessionRefresh)
 	parser.Flag("assume-role-arn", "IAM Role to assume before processing requests").Default("").StringVar(&o.AssumeRoleArn)
 	parser.Flag("region", "AWS Region to use for regional STS calls (e.g. us-west-2). Defaults to the global endpoint.").Default("").StringVar(&o.Region)
+	parser.Flag("grpc-max-connection-idle-duration", "gRPC max connection idle").Default(infiniteDuration).DurationVar(&o.KeepaliveParams.MaxConnectionIdle)
+	parser.Flag("grpc-max-connection-age-duration", "gRPC max connection age").Default(infiniteDuration).DurationVar(&o.KeepaliveParams.MaxConnectionAge)
+	parser.Flag("grpc-max-connection-age-grace-duration", "gRPC max connection age grace").Default(infiniteDuration).DurationVar(&o.KeepaliveParams.MaxConnectionAgeGrace)
 }
 
 func (cmd *serverCommand) Run() {

--- a/cmd/kiam/server.go
+++ b/cmd/kiam/server.go
@@ -15,8 +15,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"math"
 	"os"
 	"os/signal"
 	"syscall"
@@ -48,8 +46,6 @@ type serverOptions struct {
 }
 
 func (o *serverOptions) bind(parser parser) {
-	infiniteDuration := fmt.Sprintf("%ds", math.MaxInt64/1000000000)
-
 	parser.Flag("fetchers", "Number of parallel fetcher go routines").Default("8").IntVar(&o.ParallelFetcherProcesses)
 	parser.Flag("prefetch-buffer-size", "How many Pod events to hold in memory between the Pod watcher and Prefetch manager.").Default("1000").IntVar(&o.PrefetchBufferSize)
 	parser.Flag("bind", "gRPC bind address").Default("localhost:9610").StringVar(&o.BindAddress)
@@ -63,9 +59,9 @@ func (o *serverOptions) bind(parser parser) {
 	parser.Flag("session-refresh", "How soon STS Tokens should be refreshed before their expiration.").Default("5m").DurationVar(&o.SessionRefresh)
 	parser.Flag("assume-role-arn", "IAM Role to assume before processing requests").Default("").StringVar(&o.AssumeRoleArn)
 	parser.Flag("region", "AWS Region to use for regional STS calls (e.g. us-west-2). Defaults to the global endpoint.").Default("").StringVar(&o.Region)
-	parser.Flag("grpc-max-connection-idle-duration", "gRPC max connection idle").Default(infiniteDuration).DurationVar(&o.KeepaliveParams.MaxConnectionIdle)
-	parser.Flag("grpc-max-connection-age-duration", "gRPC max connection age").Default(infiniteDuration).DurationVar(&o.KeepaliveParams.MaxConnectionAge)
-	parser.Flag("grpc-max-connection-age-grace-duration", "gRPC max connection age grace").Default(infiniteDuration).DurationVar(&o.KeepaliveParams.MaxConnectionAgeGrace)
+	parser.Flag("grpc-max-connection-idle-duration", "gRPC max connection idle").Default("15m").DurationVar(&o.KeepaliveParams.MaxConnectionIdle)
+	parser.Flag("grpc-max-connection-age-duration", "gRPC max connection age").Default("15m").DurationVar(&o.KeepaliveParams.MaxConnectionAge)
+	parser.Flag("grpc-max-connection-age-grace-duration", "gRPC max connection age grace").Default("15m").DurationVar(&o.KeepaliveParams.MaxConnectionAgeGrace)
 }
 
 func (cmd *serverCommand) Run() {

--- a/cmd/kiam/server.go
+++ b/cmd/kiam/server.go
@@ -59,6 +59,8 @@ func (o *serverOptions) bind(parser parser) {
 	parser.Flag("session-refresh", "How soon STS Tokens should be refreshed before their expiration.").Default("5m").DurationVar(&o.SessionRefresh)
 	parser.Flag("assume-role-arn", "IAM Role to assume before processing requests").Default("").StringVar(&o.AssumeRoleArn)
 	parser.Flag("region", "AWS Region to use for regional STS calls (e.g. us-west-2). Defaults to the global endpoint.").Default("").StringVar(&o.Region)
+	parser.Flag("grpc-keepalive-time-duration", "gRPC keepalive time").Default("10s").DurationVar(&o.KeepaliveParams.Time)
+	parser.Flag("grpc-keepalive-timeout-duration", "gRPC keepalive timeout").Default("2s").DurationVar(&o.KeepaliveParams.Timeout)
 	parser.Flag("grpc-max-connection-idle-duration", "gRPC max connection idle").Default("15m").DurationVar(&o.KeepaliveParams.MaxConnectionIdle)
 	parser.Flag("grpc-max-connection-age-duration", "gRPC max connection age").Default("15m").DurationVar(&o.KeepaliveParams.MaxConnectionAge)
 	parser.Flag("grpc-max-connection-age-grace-duration", "gRPC max connection age grace").Default("15m").DurationVar(&o.KeepaliveParams.MaxConnectionAgeGrace)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uswitch/kiam/pkg/prefetch"
 	pb "github.com/uswitch/kiam/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -48,6 +49,7 @@ type Config struct {
 	PrefetchBufferSize           int
 	AssumeRoleArn                string
 	Region                       string
+	KeepaliveParams              keepalive.ServerParameters
 }
 
 // TLSConfig controls TLS

--- a/pkg/server/server_builder.go
+++ b/pkg/server/server_builder.go
@@ -169,6 +169,7 @@ func (b *KiamServerBuilder) WithTLS() (*KiamServerBuilder, error) {
 		grpc.Creds(b.transportCredentials),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+		grpc.KeepaliveParams(b.config.KeepaliveParams),
 	)
 
 	return b, nil


### PR DESCRIPTION
This PR adds support for configuring the `max-connection` related options for the kiam server.

Closes https://github.com/uswitch/kiam/issues/433