### PR TITLE
Set arnResolver on server in builder

### DIFF
--- a/pkg/server/server_builder.go
+++ b/pkg/server/server_builder.go
@@ -213,6 +213,7 @@ func (b *KiamServerBuilder) Build() (*KiamServer, error) {
 			NewNamespacePermittedRoleNamePolicy(!b.config.DisableStrictNamespaceRegexp, b.namespaceCache, arnResolver),
 		),
 		parallelFetchers: b.config.ParallelFetcherProcesses,
+		arnResolver:      arnResolver,
 	}
 	pb.RegisterKiamServiceServer(b.grpcServer, srv)
 	return srv, nil


### PR DESCRIPTION
Ouch my bad here we need to set the `arnResolver` on the server at build time, this will fix the segfault I am seeing with the `v4.0-beta1` release :sob: 