### PR TITLE
Log session-name and external-id when logging credentials

### DIFF
--- a/pkg/aws/sts/log.go
+++ b/pkg/aws/sts/log.go
@@ -14,13 +14,25 @@
 package sts
 
 import (
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 )
 
 func CredentialsFields(identity *RoleIdentity, creds *Credentials) log.Fields {
-	return log.Fields{
+	fields := log.Fields{
 		"credentials.access.key": creds.AccessKeyId,
 		"credentials.expiration": creds.Expiration,
 		"credentials.role":       identity.Role,
 	}
+
+	if identity.SessionName != "" {
+		fields["credentials.session-name"] = identity.SessionName
+	}
+
+	if identity.ExternalID != "" {
+		fields["credentials.external-id"] = strings.Repeat("*", len(identity.ExternalID))
+	}
+
+	return fields
 }

--- a/pkg/aws/sts/log.go
+++ b/pkg/aws/sts/log.go
@@ -23,7 +23,7 @@ func CredentialsFields(identity *RoleIdentity, creds *Credentials) log.Fields {
 	fields := log.Fields{
 		"credentials.access.key": creds.AccessKeyId,
 		"credentials.expiration": creds.Expiration,
-		"credentials.role":       identity.Role,
+		"credentials.role":       identity.Role.ARN,
 	}
 
 	if identity.SessionName != "" {


### PR DESCRIPTION
Adds the session-name and external-id to the log fields when logging credentials.

Session name is safe and easy but logging external-id worries me a little, at the moment I mask the entire string which really adds no value apart from showing me there is an external-id used and how long it might be.

We could attempt some partial masking but that again makes me nervous, thoughts @pingles ?