### PR TITLE
change helm init repo to charts.helm.sh

### DIFF
--- a/ci/helm-package.sh
+++ b/ci/helm-package.sh
@@ -12,7 +12,7 @@ then
   exit 0
 else
   # package helm chart
-  helm init --client-only
+  helm init --stable-repo-url https://charts.helm.sh/stable --client-only
   mkdir ${DRONE_WORKSPACE}/output/
   helm package ${DRONE_WORKSPACE}/helm/${APP}/ -d ${DRONE_WORKSPACE}/output/
 

--- a/helm/kiam/CHANGELOG.md
+++ b/helm/kiam/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Helm Chart Changelog
+# 5.10.0
+18 August 2020
+
+Notable changes:
+* [#415](https://github.com/uswitch/kiam/pull/415) Allow disabling of mounting SSL certs from host
+
+Many thanks to the following contributor for this release:
+* [@velothump](https://github.com/velothump)
 
 ## 5.9.0
 17 August 2020


### PR DESCRIPTION
Seems the helm repo was switched from https://kubernetes-charts.storage.googleapis.com to https://charts.helm.sh/stable at some point, this should hopefully fix the build 

Fixes: https://github.com/uswitch/kiam/issues/456