### PR TITLE
Adding ARN prefix for assumeRoleArn automatically

### DIFF
--- a/cmd/kiam/agent.go
+++ b/cmd/kiam/agent.go
@@ -89,7 +89,7 @@ func (opts *agentCommand) run() error {
 	b := kiamserver.NewKiamGatewayBuilder().WithAddress(opts.serverAddress).WithKeepAlive(opts.keepaliveParams)
 	_, err := b.WithTLS(opts.certificatePath, opts.keyPath, opts.caPath)
 	if err != nil {
-		log.Errorf("error configuring TLS: ", err.Error())
+		log.Errorf("error configuring TLS: %s", err.Error())
 		return err
 	}
 

--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -25,8 +25,6 @@ import (
 )
 
 type credentialsCache struct {
-	arnResolver     ARNResolver
-	baseARN         string
 	cache           *cache.Cache
 	expiring        chan *CachedCredentials
 	sessionName     string

--- a/pkg/server/server_builder.go
+++ b/pkg/server/server_builder.go
@@ -61,7 +61,15 @@ func (b *KiamServerBuilder) WithAWSSTSGateway() (*KiamServerBuilder, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg.WithCredentialsFromAssumedRole(sts.NewSTSCredentialsProvider(), b.config.AssumeRoleArn)
+	arnResolver, err := newRoleARNResolver(b.config)
+	if err != nil {
+		return nil, err
+	}
+	assumeRoleARN, err := arnResolver.Resolve(b.config.AssumeRoleArn)
+	if err != nil {
+		return nil, err
+	}
+	cfg.WithCredentialsFromAssumedRole(sts.NewSTSCredentialsProvider(), assumeRoleARN.ARN)
 	stsGateway, err := sts.DefaultGateway(cfg.Config())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We ran into some issues when using `--role-base-arn-autodetect` and not providing full ARN via `--assume-role-arn` in kiam v4.0 .

As you can see in the server logs, the ARN is autocompleted for the requested role by the pod (z2h2q-Route53Manager-Role) but it's not autocompleted for the role that the server has to assume (z2h2q-IAMManager-Role).

```
{"level":"error","msg":"error requesting credentials: AccessDenied: User: arn:aws:sts::999999999999:assumed-role/gs-cluster-z2h2q-role-tccpn/i-038e8e95d771c82ad is not authorized to perform: sts:AssumeRole on resource: z2h2q-IAMManager-Role\n\tstatus code: 403, request id: f5e0a631-c0cb-4a9c-beaa-580a24ef96ac","pod.iam.role":{"Name":"z2h2q-Route53Manager-Role","ARN":"arn:aws:iam::999999999999:role/z2h2q-Route53Manager-Role"},"pod.iam.roleArn":"arn:aws:iam::999999999999:role/z2h2q-Route53Manager-Role","time":"2021-01-12T16:40:19Z"}
{"generation.metadata":0,"level":"error","msg":"error warming credentials: AccessDenied: User: arn:aws:sts::999999999999:assumed-role/gs-cluster-z2h2q-role-tccpn/i-038e8e95d771c82ad is not authorized to perform: sts:AssumeRole on resource: z2h2q-IAMManager-Role\n\tstatus code: 403, request id: f5e0a631-c0cb-4a9c-beaa-580a24ef96ac","pod.iam.role":"z2h2q-Route53Manager-Role","pod.name":"external-dns-67ddc97ccd-drg9f","pod.namespace":"kube-system","pod.status.ip":"10.2.41.94","pod.status.phase":"Running","resource.version":"10056","time":"2021-01-12T16:40:19Z"}
```

This is our server parameters that we use for release 3.X and if we put the full ARN it works perfectly:

```
 containers:
     - args:
       - --json-log
       - --level=info
       - --bind=0.0.0.0:6443
       - --cert=/etc/kiam/tls/tls.crt
       - --key=/etc/kiam/tls/tls.key
       - --ca=/etc/kiam/tls/ca.crt
       - --role-base-arn-autodetect
       - --assume-role-arn=z2h2q-IAMManager-Role
       - --session-duration=15m
       - --sync=1m
       - --prometheus-listen-addr=0.0.0.0:9620
       - --prometheus-sync-interval=5s
       - --region=eu-west-1
```

The PR tries to fix adding the ARN prefix when not giving the full string.

Additionally it removes two fields from `credentialsCache` which are not used anymore and a small error when logging an error.