### PR TITLE
Use new CI creds

### DIFF
--- a/ci/helm-package.sh
+++ b/ci/helm-package.sh
@@ -20,7 +20,7 @@ else
   mkdir ${DRONE_WORKSPACE}/new-repo/ && cd ${DRONE_WORKSPACE}/new-repo/
   git init
   git config --global user.email ${CI_EMAIL}
-  git remote add origin https://${CI_USER}:${CI_TOKEN}@${REPO}
+  git remote add origin https://${DRONE_NETRC_USERNAME}:${DRONE_NETRC_PASSWORD}@${REPO}
   git fetch
   git checkout --track origin/gh-pages
   git pull


### PR DESCRIPTION
Switches to using CI integration creds for committing helm charts to the chart repo