### PR TITLE
Introduce multiarch docker image build

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,42 @@
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+name: Build release
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - uses: frabert/replace-string-action@master
+        id: formatted_version
+        with:
+          pattern: '[v]*(.*)$'
+          string: "${{ steps.get_version.outputs.VERSION }}"
+          replace-with: '$1'
+          flags: 'g'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Registry
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.multiarch
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.DOCKER_ORGANIZATION }}/kiam:${{ steps.formatted_version.outputs.replaced }}

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,0 +1,22 @@
+FROM golang:1.13.8 as build
+ENV GO111MODULE=on
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+COPY proto/ proto/
+COPY Makefile Makefile
+
+RUN CGO_ENABLED=0 go build -o bin/kiam cmd/kiam/*.go
+
+FROM alpine:3.11
+RUN apk --no-cache add iptables
+COPY --from=build /workspace/bin/kiam /kiam
+CMD []


### PR DESCRIPTION
This PR tries to address this: https://github.com/uswitch/kiam/issues/454

Our use case: We have migrated parts of our kubernetes clusters in AWS to graviton (arm) by introducing graviton based 
nodegroups. It would be really nice to be able to utilize OCI's multiarch abilities, having the same charts and letting the container daemon choose the appropriate OS architecture build.

IMPORTANT: This PR is mostly a poc to kickstart the conversation to possibly support mutliarch builds, although it does work as it is.

- Dedicated multiarch Dockerfile
The reason for a discrete Dockerfile is in order to not mess any existing pipeline. The only diff between the two files is:
```
17c17
< RUN make bin/kiam-linux-amd64
---
> RUN CGO_ENABLED=0 go build -o bin/kiam cmd/kiam/*.go
21c21
< COPY --from=build /workspace/bin/kiam-linux-amd64 /kiam
---
> COPY --from=build /workspace/bin/kiam /kiam
``` 

- Utilize github-actions with docker buildx functionality
I am not really comfortable with drone ci, so that's why github actions are utilized here. Moreover, the `docker/setup-qemu-action@v1`, `docker/setup-buildx-action@v1` and `docker/setup-buildx-action@v1` seem to do all the complex multiarch work really well.

In case github actions are introduced to the upstream repo, there are 4 github repository secrets that are needed:
**DOCKER_USERNAME**: _username used in drone.yml_
**DOCKER_PASSWORD**: _password used in drone.yml_
**DOCKER_REGISTRY**: quay.io
**DOCKER_ORGANIZATION**: uswitch

Just for reference, here is a github action run from my fork: https://github.com/commixon/kiam/actions/runs/657481318 ,
and here is a successful multiarch build 
![Screenshot 2021-03-16 at 13 30 23](https://user-images.githubusercontent.com/1412645/111309104-ccbcc000-865b-11eb-8b38-e6f1129b0c2a.png)
