### PR TITLE
K8s Security improvement: Drop unused capabilities in kiam kubernetes deployments

### DIFF
--- a/deploy/agent.yaml
+++ b/deploy/agent.yaml
@@ -42,7 +42,11 @@ spec:
         - name: kiam
           securityContext:
             capabilities:
-              add: ["NET_ADMIN"]
+              drop:
+                - ALL
+              add:
+                - NET_ADMIN
+                - NET_RAW
           image: quay.io/uswitch/kiam:master # USE A TAGGED RELEASE IN PRODUCTION
           imagePullPolicy: Always
           command:

--- a/deploy/server.daemonset.yaml
+++ b/deploy/server.daemonset.yaml
@@ -57,6 +57,12 @@ spec:
             - --sync=1m
             - --prometheus-listen-addr=0.0.0.0:9620
             - --prometheus-sync-interval=5s
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
           volumeMounts:
             - mountPath: /etc/ssl/certs
               name: ssl-certs

--- a/deploy/server.deployment.yaml
+++ b/deploy/server.deployment.yaml
@@ -64,6 +64,12 @@ spec:
             - --sync=1m
             - --prometheus-listen-addr=0.0.0.0:9620
             - --prometheus-sync-interval=5s
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
           volumeMounts:
             - mountPath: /etc/ssl/certs
               name: ssl-certs


### PR DESCRIPTION
Without the `drop: ALL` section in the `securityContext`, the container will run as root with _all_ root capabilities.


I've applied successfully to our staging cluster & verified that credentials can be assigned correctly. `NET_ADMIN` and `NET_RAW` are the only capabilities we need to keep.


prior to this change:
```
$ getpcaps 23043
Capabilities for `23043': = cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_admin,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap+eip
```

after:

```
$ getpcaps 11722
Capabilities for `11722': = cap_net_admin,cap_net_raw+eip
```