### PR TITLE
Added helm chart value option to disable strict namespace regexp mode introduced in V4

### DIFF
--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 6.0.0
+version: 6.0.1
 appVersion: 4.0
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 6.0.1
+version: 6.1.0
 appVersion: 4.0
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -13,7 +13,6 @@ $ helm install uswitch/kiam
 ## Introduction
 
 This chart bootstraps a [kiam](https://github.com/uswitch/kiam) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
-
 ## Prerequisites
   - Kubernetes 1.8+ with Beta APIs enabled
 
@@ -259,6 +258,7 @@ The following table lists the configurable parameters of the kiam chart and thei
 | `server.readinessProbe.timeoutSeconds`      | When the probe times out                                                                     | 10                           |
 | `server.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                            |
 | `server.readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                            |
+| `server.disableStrictNamespaceRegexp`       | Disable default strict namespace regexp when matching roles.                                 | `false`
 | `rbac.create`                               | If `true`, create & use RBAC resources                                                       | `true`                       |
 | `psp.create`                                | If `true`, create Pod Security Policies for the agent and server when enabled                | `false`                      |
 | `imagePullSecrets`                          | The name of the secret to use if pulling from a private registry                             | `nil`                        |

--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -13,6 +13,7 @@ $ helm install uswitch/kiam
 ## Introduction
 
 This chart bootstraps a [kiam](https://github.com/uswitch/kiam) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
 ## Prerequisites
   - Kubernetes 1.8+ with Beta APIs enabled
 

--- a/helm/kiam/templates/server-daemonset.yaml
+++ b/helm/kiam/templates/server-daemonset.yaml
@@ -111,6 +111,9 @@ spec:
             {{- if .Values.server.keepaliveParams.maxConnectionAgeGrace }}
             - --grpc-max-connection-age-grace-duration={{ .Values.server.keepaliveParams.maxConnectionAgeGrace }}
             {{- end }}
+            {{- if .Values.server.disableStrictNamespaceRegexp }}
+            - --disable-strict-namespace-regexp
+            {{- end }}
           {{- range $key, $value := .Values.server.extraArgs }}
             {{- if $value }}
             - --{{ $key }}={{ $value }}

--- a/helm/kiam/templates/server-deployment.yaml
+++ b/helm/kiam/templates/server-deployment.yaml
@@ -26,7 +26,8 @@ spec:
       {{- if .Values.server.podAnnotations }}
       annotations:
 {{ toYaml .Values.server.podAnnotations | indent 8 }}
-      {{- end }} labels:
+      {{- end }}
+      labels:
         app: {{ template "kiam.name" . }}
         component: "{{ .Values.server.name }}"
         release: {{ .Release.Name }}

--- a/helm/kiam/templates/server-deployment.yaml
+++ b/helm/kiam/templates/server-deployment.yaml
@@ -26,8 +26,7 @@ spec:
       {{- if .Values.server.podAnnotations }}
       annotations:
 {{ toYaml .Values.server.podAnnotations | indent 8 }}
-      {{- end }}
-      labels:
+      {{- end }} labels:
         app: {{ template "kiam.name" . }}
         component: "{{ .Values.server.name }}"
         release: {{ .Release.Name }}
@@ -129,6 +128,9 @@ spec:
             {{- end }}
             {{- if .Values.server.keepaliveParams.maxConnectionAgeGrace }}
             - --grpc-max-connection-age-grace-duration={{ .Values.server.keepaliveParams.maxConnectionAgeGrace }}
+            {{- end }}
+            {{- if .Values.server.disableStrictNamespaceRegexp }}
+            - --disable-strict-namespace-regexp
             {{- end }}
           {{- range $key, $value := .Values.server.extraArgs }}
             {{- if $value }}

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -390,6 +390,10 @@ server:
   #  type: spc_t
   #  level: s0
 
+  ## Disable default strict namespace regexp when matching roles
+  ## Ref: https://github.com/uswitch/kiam/blob/master/docs/UPGRADING.md
+  disableStrictNamespaceRegexp: false
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
I think the introduction of strict namespace regexp mode is a great addition to KIAM, hence it should be kept default. But configuring the flag should be more straight forward.

Thanks for the great work.