### PR TITLE
Add agent.dnsConfig to Helm chart values

### DIFF
--- a/helm/kiam/README.md
+++ b/helm/kiam/README.md
@@ -163,6 +163,7 @@ The following table lists the configurable parameters of the kiam chart and thei
 | `agent.image.tag`                           | Agent image tag                                                                              | `v3.6`                       |
 | `agent.image.pullPolicy`                    | Agent image pull policy                                                                      | `IfNotPresent`               |
 | `agent.dnsPolicy`                           | Agent pod DNS policy                                                                         | `ClusterFirstWithHostNet`    |
+| `agent.dnsConfig`                           | Agent pod DNS config                                                                         | `{}`                         |
 | `agent.allowRouteRegexp`                    | Agent metadata proxy server only allows accesses to paths matching this regexp               | `{}`                         |
 | `agent.extraArgs`                           | Additional agent container arguments                                                         | `{}`                         |
 | `agent.extraEnv`                            | Additional agent container environment variables                                             | `{}`                         |

--- a/helm/kiam/templates/agent-daemonset.yaml
+++ b/helm/kiam/templates/agent-daemonset.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: {{ .Values.agent.dnsPolicy }}
+      dnsConfig: {{ .Values.agent.dnsConfig }}
       serviceAccountName: {{ template "kiam.serviceAccountName.agent" . }}
     {{- if .Values.agent.nodeSelector }}
       nodeSelector:

--- a/helm/kiam/values.yaml
+++ b/helm/kiam/values.yaml
@@ -80,6 +80,10 @@ agent:
   ## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy
   ##
   dnsPolicy: ClusterFirstWithHostNet
+  ## Pod DNS config
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  ##
+  dnsConfig: {}
   ## Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##


### PR DESCRIPTION
In some GKE clusters, there is a bug where `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet` results in failed DNS queries.

The solution is to set `dnsPolicy: None` and provide your own `dnsConfig`.

This PR adds `agent.dnsConfig` to the Helm chart values, allowing users to implement this workaround to the GKE issue or specify any other `dnsConfig` they wish.

https://cloud.google.com/kubernetes-engine/docs/how-to/nodelocal-dns-cache#dns_timeout