### PR TITLE
Accept metadata role name request without trailing slash

### DIFF
--- a/pkg/aws/metadata/handler_role_name.go
+++ b/pkg/aws/metadata/handler_role_name.go
@@ -22,7 +22,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/uswitch/kiam/pkg/server"
 	"net/http"
-	"net/url"
 	"time"
 )
 
@@ -31,22 +30,10 @@ type roleHandler struct {
 	getClientIP clientIPFunc
 }
 
-func trailingSlashSuffixRedirectHandler(rw http.ResponseWriter, req *http.Request) {
-	u, err := url.Parse(req.URL.String())
-	if err != nil {
-		log.Errorf("error parsing uri: %s", err)
-		http.Error(rw, "error parsing uri", http.StatusInternalServerError)
-		return
-	}
-
-	u.Path = fmt.Sprintf("%s/", u.Path)
-	http.Redirect(rw, req, u.String(), http.StatusMovedPermanently)
-}
-
 func (h *roleHandler) Install(router *mux.Router) {
 	handler := adapt(withMeter("roleName", h))
 	router.Handle("/{version}/meta-data/iam/security-credentials/", handler)
-	router.HandleFunc("/{version}/meta-data/iam/security-credentials", trailingSlashSuffixRedirectHandler)
+	router.Handle("/{version}/meta-data/iam/security-credentials", handler)
 }
 
 func (h *roleHandler) Handle(ctx context.Context, w http.ResponseWriter, req *http.Request) (int, error) {


### PR DESCRIPTION
This PR reverts #121, with added test.

It seems as if between when that PR was done and now, AWS has added back the ability to use this endpoint without trailing slash. Some drivers/libraries using AWS authentication do not respect redirects (like the MongoDB Nodejs driver), and use the URL without trailing slash. This causes them to not work with KIAM.

I tested the metadata service directly with a couple different families (t3, m5, r5, c4), and they seem to all respond without a redirect (just a 200 with the role name) when trying the URL without trailing slash.