### PR TITLE
Update deprecated API versions for kube 1.22

### DIFF
--- a/helm/kiam/Chart.yaml
+++ b/helm/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 6.1.0
+version: 6.1.1
 appVersion: 4.0
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/helm/kiam/templates/server-read-clusterrole.yaml
+++ b/helm/kiam/templates/server-read-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.server.enabled -}}
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/helm/kiam/templates/server-read-clusterrolebinding.yaml
+++ b/helm/kiam/templates/server-read-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.server.enabled -}}
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/helm/kiam/templates/server-write-clusterrole.yaml
+++ b/helm/kiam/templates/server-write-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.server.enabled -}}
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/helm/kiam/templates/server-write-clusterrolebinding.yaml
+++ b/helm/kiam/templates/server-write-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.server.enabled -}}
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
[Kubernetes 1.22 removes a few apiversions for resources](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/) among which are `rbac.authorization.k8s.io/v1beta1` that is used in [clusterrolebinding](https://github.com/uswitch/kiam/blob/master/helm/kiam/templates/server-read-clusterrolebinding.yaml#L3) and [clusterrole](https://github.com/uswitch/kiam/blob/master/helm/kiam/templates/server-read-clusterrole.yaml#L3) in the kiam chart. 

This PR replaces the deprecated api versions with the stable version.  