### PR TITLE
Fix protoc error when running `make docker`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
+RUN apt-get update \
+    && apt-get install -y \
+     protobuf-compiler
 
 COPY cmd/ cmd/
 COPY pkg/ pkg/

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(BIN_LINUX): $(SOURCES)
 
 proto/service.pb.go: proto/service.proto
 	go get -u -v github.com/golang/protobuf/protoc-gen-go
-	protoc -I proto/ proto/service.proto --go_out=plugins=grpc:proto
+	protoc -I proto/ proto/service.proto --go_out=plugins=grpc:proto --go_opt=paths=source_relative
 
 test: $(SOURCES)
 	go test github.com/uswitch/kiam/pkg/... -race

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package kiam;
 
+option go_package = "github.com/uswitch/kiam/proto";
+
 service KiamService {
   rpc GetPodRole(GetPodRoleRequest) returns (Role) {}
   rpc GetPodCredentials(GetPodCredentialsRequest) returns (Credentials) {}


### PR DESCRIPTION
Fixes the protoc error when running `make docker`

Before:
```bash
make docker
docker image build -t "quay.io/uswitch/kiam:master" .
[+] Building 8.2s (18/20)
 => [internal] load build definition from Dockerfile                                                                                                                                               0.0s
 => => transferring dockerfile: 585B                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                  0.0s
 => => transferring context: 34B                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/alpine:3.11                                                                                                                                     1.4s
 => [internal] load metadata for docker.io/library/golang:1.13.8                                                                                                                                   1.4s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                                                                                                      0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                      0.0s
 => [build  1/10] FROM docker.io/library/golang:1.13.8@sha256:d7e0b99badf7f34b5096089484a733897c9b89aa12ffb9f67f81da054f8a403e                                                                     0.0s
 => [internal] load build context                                                                                                                                                                  0.0s
 => => transferring context: 5.49kB                                                                                                                                                                0.0s
 => [stage-1 1/3] FROM docker.io/library/alpine:3.11@sha256:e457c945f4be075a9e5365c6628e552fcd15551f0bc1c1fc2ea0f2227a524210                                                                       0.0s
 => CACHED [build  2/10] WORKDIR /workspace                                                                                                                                                        0.0s
 => CACHED [build  3/10] COPY go.mod go.mod                                                                                                                                                        0.0s
 => CACHED [build  4/10] COPY go.sum go.sum                                                                                                                                                        0.0s
 => CACHED [build  5/10] RUN go mod download                                                                                                                                                       0.0s
 => CACHED [build  6/10] COPY cmd/ cmd/                                                                                                                                                            0.0s
 => CACHED [build  7/10] COPY pkg/ pkg/                                                                                                                                                            0.0s
 => CACHED [build  8/10] COPY proto/ proto/                                                                                                                                                        0.0s
 => CACHED [build  9/10] COPY Makefile Makefile                                                                                                                                                    0.0s
 => ERROR [build 10/10] RUN make bin/kiam-linux-amd64                                                                                                                                              6.6s
------
 > [build 10/10] RUN make bin/kiam-linux-amd64:
#19 0.340 go get -u -v github.com/golang/protobuf/protoc-gen-go
#19 0.746 go: finding github.com/golang/protobuf v1.5.2
#19 0.795 go: downloading github.com/golang/protobuf v1.5.2
#19 1.386 go: extracting github.com/golang/protobuf v1.5.2
#19 1.549 go: finding google.golang.org/protobuf v1.27.1
#19 2.124 go: downloading google.golang.org/protobuf v1.27.1
#19 2.438 go: extracting google.golang.org/protobuf v1.27.1
#19 2.787 google.golang.org/protobuf/internal/flags
#19 2.789 google.golang.org/protobuf/internal/set
#19 2.807 google.golang.org/protobuf/internal/pragma
#19 2.812 google.golang.org/protobuf/internal/detrand
#19 2.815 google.golang.org/protobuf/internal/version
#19 2.839 google.golang.org/protobuf/internal/errors
#19 2.864 google.golang.org/protobuf/encoding/protowire
#19 2.902 google.golang.org/protobuf/reflect/protoreflect
#19 3.059 google.golang.org/protobuf/internal/encoding/messageset
#19 3.060 google.golang.org/protobuf/internal/descfmt
#19 3.060 google.golang.org/protobuf/internal/order
#19 3.060 google.golang.org/protobuf/internal/strs
#19 3.060 google.golang.org/protobuf/runtime/protoiface
#19 3.062 google.golang.org/protobuf/internal/genid
#19 3.119 google.golang.org/protobuf/reflect/protoregistry
#19 3.126 google.golang.org/protobuf/internal/descopts
#19 3.154 google.golang.org/protobuf/internal/encoding/text
#19 3.239 google.golang.org/protobuf/proto
#19 3.312 google.golang.org/protobuf/internal/encoding/defval
#19 3.459 google.golang.org/protobuf/encoding/prototext
#19 3.460 google.golang.org/protobuf/internal/filedesc
#19 3.791 google.golang.org/protobuf/internal/encoding/tag
#19 3.844 google.golang.org/protobuf/internal/impl
#19 4.678 google.golang.org/protobuf/internal/filetype
#19 4.770 google.golang.org/protobuf/runtime/protoimpl
#19 4.827 google.golang.org/protobuf/types/descriptorpb
#19 5.053 google.golang.org/protobuf/types/pluginpb
#19 5.053 google.golang.org/protobuf/reflect/protodesc
#19 5.305 google.golang.org/protobuf/compiler/protogen
#19 5.466 github.com/golang/protobuf/internal/gengogrpc
#19 5.467 google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo
#19 5.811 github.com/golang/protobuf/protoc-gen-go
#19 6.508 protoc -I proto/ proto/service.proto --go_out=plugins=grpc:proto
#19 6.511 make: protoc: Command not found
#19 6.512 make: *** [Makefile:25: proto/service.pb.go] Error 127
------
executor failed running [/bin/sh -c make bin/kiam-linux-amd64]: exit code: 2
make: *** [docker] Error 1
```

After:
```bash
make docker
docker image build -t "quay.io/uswitch/kiam:fix-protoc-error-make-docker" .
[+] Building 48.9s (20/20) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                               0.0s
 => => transferring dockerfile: 44B                                                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                  0.0s
 => => transferring context: 34B                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/alpine:3.11                                                                                                                                     0.6s
 => [internal] load metadata for docker.io/library/golang:1.13.8                                                                                                                                   0.6s
 => [internal] load build context                                                                                                                                                                  0.0s
 => => transferring context: 4.37kB                                                                                                                                                                0.0s
 => [build  1/11] FROM docker.io/library/golang:1.13.8@sha256:d7e0b99badf7f34b5096089484a733897c9b89aa12ffb9f67f81da054f8a403e                                                                     0.0s
 => [stage-1 1/3] FROM docker.io/library/alpine:3.11@sha256:e457c945f4be075a9e5365c6628e552fcd15551f0bc1c1fc2ea0f2227a524210                                                                       0.0s
 => CACHED [stage-1 2/3] RUN apk --no-cache add iptables                                                                                                                                           0.0s
 => CACHED [build  2/11] WORKDIR /workspace                                                                                                                                                        0.0s
 => CACHED [build  3/11] COPY go.mod go.mod                                                                                                                                                        0.0s
 => CACHED [build  4/11] COPY go.sum go.sum                                                                                                                                                        0.0s
 => CACHED [build  5/11] RUN go mod download                                                                                                                                                       0.0s
 => CACHED [build  6/11] RUN apt-get update     && apt-get install -y      protobuf-compiler                                                                                                       0.0s
 => CACHED [build  7/11] COPY cmd/ cmd/                                                                                                                                                            0.0s
 => CACHED [build  8/11] COPY pkg/ pkg/                                                                                                                                                            0.0s
 => CACHED [build  9/11] COPY proto/ proto/                                                                                                                                                        0.0s
 => [build 10/11] COPY Makefile Makefile                                                                                                                                                           0.0s
 => [build 11/11] RUN make bin/kiam-linux-amd64                                                                                                                                                   46.9s
 => [stage-1 3/3] COPY --from=build /workspace/bin/kiam-linux-amd64 /kiam                                                                                                                          0.2s
 => exporting to image                                                                                                                                                                             0.5s
 => => exporting layers                                                                                                                                                                            0.4s
 => => writing image sha256:a223fd5a1d7575a68e52fbe3a97a02ae25c883d0b08d09a27fc802ec2ba587b0                                                                                                       0.0s
 => => naming to quay.io/uswitch/kiam:fix-protoc-error-make-docker
```
Signed-off-by: kevdowney <kevdowney@gmail.com>