### PR TITLE
Add STS Session Tagging support through the use of pod annotations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,31 @@ metadata:
     iam.amazonaws.com/external-id: dac7ad46-acab-4ec3-a78e-f3962ecf45d7
 ```
 
+You can also set [session tags](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) for each pod that then can be referenced in your IAM policies. The following example sets the key as `user` with the value of `example-user`
+```yaml
+kind: Pod
+metadata:
+  name: foo
+  namespace: external-id-example
+  annotations:
+    iam.amazonaws.com/role: reportingdb-reader
+    iam.amazonaws.com/session-tag.user: example-user
+```
+
+In your IAM policy you can then reference these key/value pairs, like so:
+```
+{
+  "Sid": "AllowAllS3OperationsForACertainPrefix",
+  "Effect": "Allow",
+  "Action": ["s3:*"],
+  "Resource": ["arn:aws:s3:::example-bucket/${aws:PrincipalTag/user}/*"]
+}
+```
+
+This allows you to use a single generic IAM policy, but still maintain the granularity as if you were to have multiple roles (in this example one per user).
+
+**Note:** You must add the `sts:TagSession` permission to your trust policy if you plan to use this feature.
+
 Further, all namespaces must also have an annotation with a regular expression expressing which roles are permitted to be assumed within that namespace. **Without the namespace annotation the pod will be unable to assume any roles.**
 
 ```yaml

--- a/docs/IAM.md
+++ b/docs/IAM.md
@@ -137,6 +137,24 @@ resource "aws_iam_policy_attachment" "server_policy_attach" {
 }
 ```
 
+### Session Tags
+IAM [Session Tags](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) are key-value pair attributes that you can pass through as annotations for your pods. These are then passed along to the Assume Role request to AWS. When you pass through one or more session tags you can reference these within your IAM policies under `aws:PrincipalTag/<tag_name>`.
+
+However, in order to do this the Kiam server role _must_ also have the `sts:TagSession` permission, like so:
+
+```
+{
+  "Effect": "Allow",
+  "Principal": {
+    "AWS": "arn:aws:iam::123456789012:role/kiam-server"
+  },
+  "Action": [
+    "sts:AssumeRole",
+    "sts:TagSession"
+  ]
+}
+```
+
 ## Application Roles
 
 For any role which is to be assumed by a Pod you'll need to ensure it also has a

--- a/pkg/aws/sts/cache.go
+++ b/pkg/aws/sts/cache.go
@@ -118,6 +118,7 @@ func (c *credentialsCache) CredentialsForRole(ctx context.Context, identity *Rol
 			SessionName:     sessionName,
 			ExternalID:      identity.ExternalID,
 			SessionDuration: c.sessionDuration,
+			SessionTags:     identity.SessionTags,
 		}
 
 		credentials, err := c.gateway.Issue(ctx, stsIssueRequest)

--- a/pkg/aws/sts/gateway.go
+++ b/pkg/aws/sts/gateway.go
@@ -28,6 +28,7 @@ type STSIssueRequest struct {
 	SessionName     string
 	ExternalID      string
 	SessionDuration time.Duration
+	SessionTags     map[string]string
 }
 
 type STSGateway interface {
@@ -58,6 +59,17 @@ func (g *DefaultSTSGateway) Issue(ctx context.Context, request *STSIssueRequest)
 
 	if request.ExternalID != "" {
 		in.ExternalId = aws.String(request.ExternalID)
+	}
+
+	if len(request.SessionTags) > 0 {
+		tags := []*sts.Tag{}
+		for k, v := range request.SessionTags {
+			tags = append(tags, &sts.Tag{
+				Key:   aws.String(k),
+				Value: aws.String(v),
+			})
+		}
+		in.SetTags(tags)
 	}
 
 	resp, err := svc.AssumeRoleWithContext(ctx, in)

--- a/pkg/aws/sts/role_identity_test.go
+++ b/pkg/aws/sts/role_identity_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 uSwitch
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sts
+
+import (
+	"fmt"
+	"testing"
+)
+
+const rolePrefix = "arn:aws:iam::account-id:role/"
+
+func TestRoleIdentity(t *testing.T) {
+	testCases := []struct {
+		role, sessionName, externalID string
+		sessionTags                   map[string]string
+		expectedIdentity              string
+	}{
+		{
+			role:             "example-role",
+			expectedIdentity: "arn:aws:iam::account-id:role/example-role||",
+		},
+		{
+			sessionName:      "db-reader",
+			role:             "example-role",
+			expectedIdentity: "arn:aws:iam::account-id:role/example-role|db-reader|",
+		},
+		{
+			sessionName:      "db-reader",
+			externalID:       "07091992",
+			role:             "example-role",
+			expectedIdentity: "arn:aws:iam::account-id:role/example-role|db-reader|07091992",
+		},
+		{
+			sessionName:      "db-reader",
+			externalID:       "07091992",
+			role:             "example-role",
+			sessionTags:      map[string]string{"foo": "bar"},
+			expectedIdentity: "arn:aws:iam::account-id:role/example-role|db-reader|07091992|foo:bar",
+		},
+		{
+			sessionName: "db-reader",
+			externalID:  "07091992",
+			role:        "example-role",
+			sessionTags: map[string]string{
+				"foo":     "bar",
+				"another": "example",
+			},
+			expectedIdentity: "arn:aws:iam::account-id:role/example-role|db-reader|07091992|another:example,foo:bar",
+		},
+	}
+	for _, tc := range testCases {
+		resolver := DefaultResolver(rolePrefix)
+		desc := fmt.Sprintf("test role=%s, session name=%s, external ID=%s, tags= %v", tc.role, tc.sessionName, tc.externalID, tc.sessionTags)
+		t.Run(desc, func(t *testing.T) {
+			id, err := NewRoleIdentity(resolver, tc.role, tc.sessionName, tc.externalID, tc.sessionTags)
+			if err != nil {
+				t.Errorf("NewRoleIdentity() = %v, want nil error", err)
+			}
+			if id.String() != tc.expectedIdentity {
+				t.Errorf("id.String() = %s, want = %s", id.String(), tc.expectedIdentity)
+			}
+		})
+	}
+}

--- a/pkg/prefetch/manager.go
+++ b/pkg/prefetch/manager.go
@@ -45,8 +45,9 @@ func (m *CredentialManager) fetchCredentials(ctx context.Context, pod *v1.Pod) {
 	role := k8s.PodRole(pod)
 	sessionName := k8s.PodSessionName(pod)
 	externalID := k8s.PodExternalID(pod)
+	sessionTags := k8s.PodSessionTags(pod)
 
-	identity, err := sts.NewRoleIdentity(m.arnResolver, role, sessionName, externalID)
+	identity, err := sts.NewRoleIdentity(m.arnResolver, role, sessionName, externalID, sessionTags)
 	if err != nil {
 		logger.Errorf("error creating role identity: %s", err.Error())
 		return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -110,8 +110,9 @@ func (k *KiamServer) GetPodCredentials(ctx context.Context, req *pb.GetPodCreden
 
 	sessionName := k8s.PodSessionName(pod)
 	externalID := k8s.PodExternalID(pod)
+	sessionTags := k8s.PodSessionTags(pod)
 
-	identity, err := sts.NewRoleIdentity(k.arnResolver, req.Role, sessionName, externalID)
+	identity, err := sts.NewRoleIdentity(k.arnResolver, req.Role, sessionName, externalID, sessionTags)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change introduces the ability to set session tags for each pod, that then get passed through to the AssumeRole API call.

These session tags can then be referenced throughout your IAM policies. This allows you to use a single IAM role but apply it in different ways, for instance restricting users to certain resources based on a single tag.

Users can set 0 or more (up to 50) session tags with the following format:
```
iam.amazonaws.com/session-tag.KEY: VALUE
```

for example:
```
iam.amazonaws.com/session-tag.user: example
```

This can then be referenced through your IAM Policy as `${aws:PrincipalTag/user}` allowing for more generic IAM policies that can be influenced dynamically.

In order to use this feature users will need to apply the `sts:TagSession` permission in their trust policies.

This fixes https://github.com/uswitch/kiam/issues/462